### PR TITLE
feat: introduce CustomError handling for EthCall

### DIFF
--- a/abi/src/main/java/org/web3j/abi/datatypes/CustomError.java
+++ b/abi/src/main/java/org/web3j/abi/datatypes/CustomError.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2024 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.abi.datatypes;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.web3j.abi.TypeReference;
+import org.web3j.abi.Utils;
+
+/** 
+ * Represents a Solidity custom error definition.
+ * This class defines the structure of a custom error, not its values.
+ * The parameters list contains TypeReferences that define what types of values
+ * the error can contain, not the actual values themselves.
+ */
+public class CustomError {
+    private final String name;
+    private final List<TypeReference<?>> parameters;
+
+    public CustomError(String name, List<TypeReference<?>> parameters) {
+        this.name = name;
+        this.parameters = parameters;
+    }
+
+    public CustomError(String name) {
+        this(name, new ArrayList<>());
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<TypeReference<?>> getParameters() {
+        return parameters;
+    }
+
+    /**
+     * Returns the error signature in the format "ErrorName(type1,type2,...)"
+     */
+    public String getSignature() {
+        StringBuilder signature = new StringBuilder();
+        signature.append(name).append("(");
+        for (int i = 0; i < parameters.size(); i++) {
+            signature.append(Utils.getSolidityTypeName(parameters.get(i)));
+            if (i < parameters.size() - 1) {
+                signature.append(",");
+            }
+        }
+        signature.append(")");
+        return signature.toString();
+    }
+
+    /**
+     * Returns the first 4 bytes of the Keccak-256 hash of the error signature.
+     * This is used to identify the error in transaction receipts.
+     */
+    public String getSelector() {
+        return org.web3j.crypto.Hash.sha3String(getSignature()).substring(0, 10);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CustomError that = (CustomError) o;
+        return this.getSignature().equals(that.getSignature());
+    }
+
+    @Override
+    public int hashCode() {
+        return getSignature().hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return getSignature();
+    }
+} 

--- a/abi/src/test/java/org/web3j/abi/datatypes/CustomErrorTest.java
+++ b/abi/src/test/java/org/web3j/abi/datatypes/CustomErrorTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2024 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.abi.datatypes;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import org.web3j.abi.TypeReference;
+import org.web3j.abi.datatypes.AbiTypes;
+import org.web3j.abi.datatypes.generated.Uint256;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class CustomErrorTest {
+
+    @Test
+    public void testEmptyCustomError() {
+        CustomError error = new CustomError("SimpleError");
+        assertEquals(
+            "SimpleError()", 
+            error.getSignature(),
+            "Empty error should have signature 'SimpleError()'"
+        );
+        assertEquals(
+            "0xc2bb947c", 
+            error.getSelector(),
+            "Selector should match keccak256('SimpleError()')"
+        );
+    }
+
+    @Test
+    public void testCustomErrorWithParameters() {
+        List<TypeReference<?>> parameters = Arrays.asList(
+            TypeReference.create(Address.class),
+            TypeReference.create(Uint256.class),
+            TypeReference.create(Utf8String.class)
+        );
+        
+        CustomError error = new CustomError("ComplexError", parameters);
+        
+        String expectedSignature = "ComplexError(address,uint256,string)";
+        assertEquals(
+            expectedSignature,
+            error.getSignature(),
+            "Error signature should match '" + expectedSignature + "'"
+        );
+        assertEquals(
+            parameters,
+            error.getParameters(),
+            "Parameters list should match the input parameters"
+        );
+        assertEquals(
+            "0xcca85a17",
+            error.getSelector(),
+            "Selector should match keccak256('" + expectedSignature + "')"
+        );
+    }
+
+    @Test
+    public void testCustomErrorWithArrayParameter() {
+        List<TypeReference<?>> parameters = Collections.singletonList(
+            new TypeReference<DynamicArray<Uint256>>() {}
+        );
+        
+        CustomError error = new CustomError("ArrayError", parameters);
+        
+        String expectedSignature = "ArrayError(uint256[])";
+        assertEquals(
+            expectedSignature,
+            error.getSignature(),
+            "Error signature should match '" + expectedSignature + "'"
+        );
+        assertEquals(
+            parameters,
+            error.getParameters(),
+            "Parameters list should match the input parameters"
+        );
+        assertEquals(
+            "0x6300af57",
+            error.getSelector(),
+            "Selector should match keccak256('" + expectedSignature + "')"
+        );
+    }
+
+    @Test
+    public void testEquality() {
+        List<TypeReference<?>> parameters1 = Arrays.asList(
+            TypeReference.create(Address.class),
+            TypeReference.create(Uint256.class)
+        );
+        
+        List<TypeReference<?>> parameters2 = Arrays.asList(
+            TypeReference.create(Address.class),
+            TypeReference.create(Uint256.class)
+        );
+        
+        CustomError error1 = new CustomError("TestError", parameters1);
+        CustomError error2 = new CustomError("TestError", parameters2);
+        CustomError error3 = new CustomError("DifferentError", parameters1);
+        
+        assertEquals(
+            error1,
+            error2,
+            "Errors with same name and parameters should be equal"
+        );
+        assertNotEquals(
+            error1,
+            error3,
+            "Errors with different names should not be equal"
+        );
+    }
+
+    @Test
+    public void testToString() {
+        List<TypeReference<?>> parameters = Arrays.asList(
+            TypeReference.create(Address.class),
+            TypeReference.create(Uint256.class)
+        );
+        
+        CustomError error = new CustomError("TestError", parameters);
+        String expectedString = "TestError(address,uint256)";
+        assertEquals(
+            expectedString,
+            error.toString(),
+            "toString() should return the error signature '" + expectedString + "'"
+        );
+    }
+} 


### PR DESCRIPTION
### What does this PR do?
Supports Custom Error handling for `EthCall`, which partially closes https://github.com/hyperledger-web3j/web3j/issues/1812

### Where should the reviewer start?
PR in progresss

### Why is it needed?

Added support for custom errors in Solidity 0.8.x to improve compatibility. Custom errors are more gas-efficient than revert strings and provide structured error handling. This update enables proper decoding and handling of these errors in Web3J

## Checklist

- [ ] I've read the contribution guidelines.
- [ ] I've added tests (if applicable).
- [ ] I've added a changelog entry if necessary.