### PR TITLE
fix: ENS CCIP Read improvements

### DIFF
--- a/core/src/main/java/org/web3j/dto/EnsGatewayRequestDTO.java
+++ b/core/src/main/java/org/web3j/dto/EnsGatewayRequestDTO.java
@@ -16,11 +16,17 @@ package org.web3j.dto;
 public class EnsGatewayRequestDTO {
 
     private String data;
+    private String sender;
 
     public EnsGatewayRequestDTO() {}
 
     public EnsGatewayRequestDTO(String data) {
         this.data = data;
+    }
+
+    public EnsGatewayRequestDTO(String data, String sender) {
+        this.data = data;
+        this.sender = sender;
     }
 
     public String getData() {
@@ -29,5 +35,13 @@ public class EnsGatewayRequestDTO {
 
     public void setData(String data) {
         this.data = data;
+    }
+
+    public String getSender() {
+        return sender;
+    }
+
+    public void setSender(String sender) {
+        this.sender = sender;
     }
 }

--- a/core/src/main/java/org/web3j/ens/EnsResolver.java
+++ b/core/src/main/java/org/web3j/ens/EnsResolver.java
@@ -263,10 +263,11 @@ public class EnsResolver {
             EnsGatewayResponseDTO gatewayResponseDTO =
                     objectMapper.readValue(gatewayResult, EnsGatewayResponseDTO.class);
             String callbackSelector = Numeric.toHexString(offchainLookup.getCallbackFunction());
-            List<Type> parameters = Arrays.asList(
-                    new DynamicBytes(Numeric.hexStringToByteArray(gatewayResponseDTO.getData())),
-                    new DynamicBytes(offchainLookup.getExtraData())
-            );
+            List<Type> parameters =
+                    Arrays.asList(
+                            new DynamicBytes(
+                                    Numeric.hexStringToByteArray(gatewayResponseDTO.getData())),
+                            new DynamicBytes(offchainLookup.getExtraData()));
 
             String encodedParams = new DefaultFunctionEncoder().encodeParameters(parameters);
             String encodedFunction = callbackSelector + encodedParams;

--- a/core/src/main/java/org/web3j/utils/EnsUtils.java
+++ b/core/src/main/java/org/web3j/utils/EnsUtils.java
@@ -30,7 +30,7 @@ public class EnsUtils {
         }
 
         return EnsUtils.EIP_3668_CCIP_INTERFACE_ID.equals(
-            Numeric.removeDoubleQuotes(data).substring(0, 10));
+                Numeric.removeDoubleQuotes(data).substring(0, 10));
     }
 
     public static String getParent(String url) {

--- a/core/src/main/java/org/web3j/utils/EnsUtils.java
+++ b/core/src/main/java/org/web3j/utils/EnsUtils.java
@@ -29,7 +29,8 @@ public class EnsUtils {
             return false;
         }
 
-        return EnsUtils.EIP_3668_CCIP_INTERFACE_ID.equals(data.substring(0, 10));
+        return EnsUtils.EIP_3668_CCIP_INTERFACE_ID.equals(
+            Numeric.removeDoubleQuotes(data).substring(0, 10));
     }
 
     public static String getParent(String url) {

--- a/core/src/test/java/org/web3j/ens/EnsResolverTest.java
+++ b/core/src/test/java/org/web3j/ens/EnsResolverTest.java
@@ -281,13 +281,58 @@ class EnsResolverTest {
     }
 
     @Test
-    void buildRequestWhenNotValidUrl() {
+    void buildRequestWithDataParameterOnly() throws Exception {
         String url = "https://example.com/gateway/{data}.json";
         sender = "0x226159d592E2b063810a10Ebf6dcbADA94Ed68b8";
         data = "0xd5fa2b00";
 
-        assertThrows(
-                EnsResolutionException.class, () -> ensResolver.buildRequest(url, sender, data));
+        okhttp3.Request request = ensResolver.buildRequest(url, sender, data);
+        
+        assertEquals("https://example.com/gateway/0xd5fa2b00.json", request.url().toString());
+        assertEquals("GET", request.method());
+        assertNull(request.body());
+    }
+
+    @Test
+    void buildRequestWithSenderParameterOnly() throws Exception {
+        String url = "https://example.com/gateway/{sender}/lookup";
+        sender = "0x226159d592E2b063810a10Ebf6dcbADA94Ed68b8";
+        data = "0xd5fa2b00";
+
+        okhttp3.Request request = ensResolver.buildRequest(url, sender, data);
+        
+        assertEquals("https://example.com/gateway/0x226159d592E2b063810a10Ebf6dcbADA94Ed68b8/lookup", 
+                request.url().toString());
+        assertEquals("POST", request.method());
+        assertNotNull(request.body());
+        assertEquals("application/json", request.header("Content-Type"));
+    }
+
+    @Test
+    void verifyPostRequestBodyContainsSenderAndData() throws Exception {
+        String url = "https://example.com/gateway/lookup";
+        sender = "0x226159d592E2b063810a10Ebf6dcbADA94Ed68b8";
+        data = "0xd5fa2b00";
+
+        okhttp3.Request request = ensResolver.buildRequest(url, sender, data);
+        assertNotNull(request.body());
+        okhttp3.MediaType contentType = request.body().contentType();
+        assertNotNull(contentType);
+        assertTrue(contentType.toString().startsWith("application/json"));
+    }
+
+    @Test
+    void buildRequestWithBothParameters() throws Exception {
+        String url = "https://example.com/gateway/{sender}/{data}";
+        sender = "0x226159d592E2b063810a10Ebf6dcbADA94Ed68b8";
+        data = "0xd5fa2b00";
+
+        okhttp3.Request request = ensResolver.buildRequest(url, sender, data);
+        
+        assertEquals("https://example.com/gateway/0x226159d592E2b063810a10Ebf6dcbADA94Ed68b8/0xd5fa2b00", 
+                request.url().toString());
+        assertEquals("GET", request.method());
+        assertNull(request.body());
     }
 
     @Test

--- a/core/src/test/java/org/web3j/ens/EnsResolverTest.java
+++ b/core/src/test/java/org/web3j/ens/EnsResolverTest.java
@@ -288,7 +288,7 @@ class EnsResolverTest {
         data = "0xd5fa2b00";
 
         okhttp3.Request request = ensResolver.buildRequest(url, sender, data);
-        
+
         assertEquals("https://example.com/gateway/0xd5fa2b00.json", request.url().toString());
         assertEquals("GET", request.method());
         assertNull(request.body());
@@ -301,8 +301,9 @@ class EnsResolverTest {
         data = "0xd5fa2b00";
 
         okhttp3.Request request = ensResolver.buildRequest(url, sender, data);
-        
-        assertEquals("https://example.com/gateway/0x226159d592E2b063810a10Ebf6dcbADA94Ed68b8/lookup", 
+
+        assertEquals(
+                "https://example.com/gateway/0x226159d592E2b063810a10Ebf6dcbADA94Ed68b8/lookup",
                 request.url().toString());
         assertEquals("POST", request.method());
         assertNotNull(request.body());
@@ -329,8 +330,9 @@ class EnsResolverTest {
         data = "0xd5fa2b00";
 
         okhttp3.Request request = ensResolver.buildRequest(url, sender, data);
-        
-        assertEquals("https://example.com/gateway/0x226159d592E2b063810a10Ebf6dcbADA94Ed68b8/0xd5fa2b00", 
+
+        assertEquals(
+                "https://example.com/gateway/0x226159d592E2b063810a10Ebf6dcbADA94Ed68b8/0xd5fa2b00",
                 request.url().toString());
         assertEquals("GET", request.method());
         assertNull(request.body());
@@ -492,7 +494,8 @@ class EnsResolverTest {
                         buildResponse(200, urls.get(0), sender, data));
 
         String eip3668Data = EnsUtils.EIP_3668_CCIP_INTERFACE_ID + "data";
-        when(resolver.executeCallWithoutDecoding(any())).thenReturn(eip3668Data, eip3668Data, eip3668Data);
+        when(resolver.executeCallWithoutDecoding(any()))
+                .thenReturn(eip3668Data, eip3668Data, eip3668Data);
 
         assertThrows(
                 EnsResolutionException.class,
@@ -514,18 +517,21 @@ class EnsResolverTest {
 
         // Create a custom LOOKUP_HEX with a different callback function
         String customCallbackSelector = "aabbccdd";
-        String customLookupHex = LOOKUP_HEX.substring(0, 202) + customCallbackSelector + LOOKUP_HEX.substring(210);
-        
+        String customLookupHex =
+                LOOKUP_HEX.substring(0, 202) + customCallbackSelector + LOOKUP_HEX.substring(210);
+
         // Capture the function call to verify the correct callback selector is used
         ArgumentCaptor<String> functionCallCaptor = ArgumentCaptor.forClass(String.class);
-        when(resolver.executeCallWithoutDecoding(functionCallCaptor.capture())).thenReturn(RESOLVED_NAME_HEX);
+        when(resolver.executeCallWithoutDecoding(functionCallCaptor.capture()))
+                .thenReturn(RESOLVED_NAME_HEX);
 
         String result = ensResolver.resolveOffchain(customLookupHex, resolver, 4);
         assertEquals("0x41563129cdbbd0c5d3e1c86cf9563926b243834d", result);
-        
+
         // Verify that the captured function call starts with our custom callback selector
         String capturedFunctionCall = functionCallCaptor.getValue();
-        assertTrue(capturedFunctionCall.startsWith("0x" + customCallbackSelector),
+        assertTrue(
+                capturedFunctionCall.startsWith("0x" + customCallbackSelector),
                 "Function call should start with the custom callback selector");
     }
 
@@ -541,27 +547,30 @@ class EnsResolverTest {
 
         EnsGatewayResponseDTO responseDTO = new EnsGatewayResponseDTO(testData);
         String responseJson = om.writeValueAsString(responseDTO);
-        
-        okhttp3.Response responseObj = new okhttp3.Response.Builder()
-                .request(new okhttp3.Request.Builder().url(urls.get(0)).build())
-                .protocol(Protocol.HTTP_2)
-                .code(200)
-                .body(ResponseBody.create(responseJson, JSON_MEDIA_TYPE))
-                .message("OK")
-                .build();
-                
+
+        okhttp3.Response responseObj =
+                new okhttp3.Response.Builder()
+                        .request(new okhttp3.Request.Builder().url(urls.get(0)).build())
+                        .protocol(Protocol.HTTP_2)
+                        .code(200)
+                        .body(ResponseBody.create(responseJson, JSON_MEDIA_TYPE))
+                        .message("OK")
+                        .build();
+
         ensResolver.setHttpClient(httpClientMock);
         when(httpClientMock.newCall(any())).thenReturn(call);
         when(call.execute()).thenReturn(responseObj);
 
         ArgumentCaptor<String> functionCallCaptor = ArgumentCaptor.forClass(String.class);
-        when(resolver.executeCallWithoutDecoding(functionCallCaptor.capture())).thenReturn(RESOLVED_NAME_HEX);
+        when(resolver.executeCallWithoutDecoding(functionCallCaptor.capture()))
+                .thenReturn(RESOLVED_NAME_HEX);
 
         String result = ensResolver.resolveOffchain(LOOKUP_HEX, resolver, 4);
         assertEquals("0x41563129cdbbd0c5d3e1c86cf9563926b243834d", result);
 
         String capturedFunctionCall = functionCallCaptor.getValue();
-        assertTrue(capturedFunctionCall.contains(testData.substring(2)), 
+        assertTrue(
+                capturedFunctionCall.contains(testData.substring(2)),
                 "Function call should contain the encoded test data");
     }
 

--- a/core/src/test/java/org/web3j/utils/EnsUtilsTest.java
+++ b/core/src/test/java/org/web3j/utils/EnsUtilsTest.java
@@ -56,4 +56,26 @@ class EnsUtilsTest {
     void getParentWhenUrlWithoutParent() {
         assertNull(EnsUtils.getParent("parent"));
     }
+
+    @Test
+    public void testIsEIP3668() {
+        // Valid EIP3668 data
+        String validData = "0x556f1830abcdef1234567890";
+        assertTrue(EnsUtils.isEIP3668(validData));
+
+        String validDataWithQuotes = "\"0x556f1830abcdef1234567890\"";
+        assertTrue(EnsUtils.isEIP3668(validDataWithQuotes));
+        
+        // Invalid EIP3668 data - different interface ID
+        String invalidData = "0x123456789abcdef1234567890";
+        assertFalse(EnsUtils.isEIP3668(invalidData));
+
+        String invalidDataWithQuotes = "\"0x123456789abcdef1234567890\"";
+        assertFalse(EnsUtils.isEIP3668(invalidDataWithQuotes));
+        
+        // Edge cases
+        assertFalse(EnsUtils.isEIP3668(null));
+        assertFalse(EnsUtils.isEIP3668(""));
+        assertFalse(EnsUtils.isEIP3668("0x123"));
+    }
 }

--- a/core/src/test/java/org/web3j/utils/EnsUtilsTest.java
+++ b/core/src/test/java/org/web3j/utils/EnsUtilsTest.java
@@ -65,14 +65,14 @@ class EnsUtilsTest {
 
         String validDataWithQuotes = "\"0x556f1830abcdef1234567890\"";
         assertTrue(EnsUtils.isEIP3668(validDataWithQuotes));
-        
+
         // Invalid EIP3668 data - different interface ID
         String invalidData = "0x123456789abcdef1234567890";
         assertFalse(EnsUtils.isEIP3668(invalidData));
 
         String invalidDataWithQuotes = "\"0x123456789abcdef1234567890\"";
         assertFalse(EnsUtils.isEIP3668(invalidDataWithQuotes));
-        
+
         // Edge cases
         assertFalse(EnsUtils.isEIP3668(null));
         assertFalse(EnsUtils.isEIP3668(""));


### PR DESCRIPTION
### What does this PR do?
The current implementation of [ERC-3668: CCIP Read](https://eips.ethereum.org/EIPS/eip-3668) for ENS name resolution is too strict and doesn't follow the standard exactly.
- Currently, the `{sender}` parameter is enforced in URL while the standard specifies that it can be sent in POST as part of DTO.
- Currently, the callback request is always made to the hard-coded `resolveWithProof` method while the standard specifies that the `callbackFunction` from OffchainLookup should be used.
- Data in the `isEIP3668` method might have double quotes that must be stripped.

### Where should the reviewer start?
The ERC-3668: https://eips.ethereum.org/EIPS/eip-3668#abstract

### Why is it needed?
These problems prevent L2 subdomains created with [Durin](https://durin.dev/) from being resolved, as well as others like `base.eth` subdomains.

## Checklist

- [x] I've read the contribution guidelines.
- [x] I've added tests (if applicable).
- [ ] I've added a changelog entry if necessary.