### PR TITLE
fix: dynamic array encoding

### DIFF
--- a/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
@@ -15,7 +15,6 @@ package org.web3j.crypto;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -307,10 +306,24 @@ public class StructuredDataEncoder {
 
         List<String> encTypes = new ArrayList<>();
         List<Object> encValues = new ArrayList<>();
+        List<byte[]> dynamicData = new ArrayList<>(); // Store dynamic data
 
         // Add typehash
         encTypes.add("bytes32");
         encValues.add(typeHash(primaryType));
+
+        // Calculate header size (static part)
+        int headSize = 32; // typehash
+        for (StructuredData.Entry field : types.get(primaryType)) {
+            if (field.getType().contains("[]")) {
+                headSize += 32; // Dynamic array offset takes 32 bytes
+            } else {
+                headSize += 32; // Static type takes 32 bytes
+            }
+        }
+
+        // Track total size of dynamic data
+        int dynamicDataSize = 0;
 
         // Add field contents
         for (StructuredData.Entry field : types.get(primaryType)) {
@@ -337,42 +350,64 @@ public class StructuredDataEncoder {
             } else if (arrayTypePattern.matcher(field.getType()).find()) {
                 String baseTypeName = field.getType().substring(0, field.getType().indexOf('['));
                 List<Object> arrayItems = getArrayItems(field, value);
-                ByteArrayOutputStream concatenatedArrayEncodingBuffer = new ByteArrayOutputStream();
 
-                for (Object arrayItem : arrayItems) {
-                    byte[] arrayItemEncoding;
-                    if (types.containsKey(baseTypeName)) {
-                        arrayItemEncoding =
-                                sha3(
-                                        encodeData(
-                                                baseTypeName,
-                                                (HashMap<String, Object>)
-                                                        arrayItem)); // need to hash each user type
-                        // before adding
-                    } else {
-                        arrayItemEncoding =
-                                convertToEncodedItem(
-                                        baseTypeName,
-                                        arrayItem); // add raw item, packed to 32 bytes
+                if (baseTypeName.startsWith("uint")
+                        || baseTypeName.startsWith("int")
+                        || baseTypeName.equals("address")
+                        || baseTypeName.equals("bool")) {
+                    // Handle dynamic array
+                    encTypes.add(baseTypeName); // Use base type instead of array type
+                    // Add offset position, considering actual size of all previous dynamic data
+                    encValues.add(BigInteger.valueOf(headSize + dynamicDataSize));
+
+                    // Prepare dynamic data
+                    ByteArrayOutputStream dynamicBuffer = new ByteArrayOutputStream();
+                    // Write array length
+                    byte[] lengthBytes =
+                            Numeric.toBytesPadded(BigInteger.valueOf(arrayItems.size()), 32);
+                    dynamicBuffer.write(lengthBytes, 0, lengthBytes.length);
+
+                    // Write array elements
+                    for (Object arrayItem : arrayItems) {
+                        BigInteger itemValue = convertToBigInt(arrayItem);
+                        byte[] itemBytes = Numeric.toBytesPadded(itemValue, 32);
+                        dynamicBuffer.write(itemBytes, 0, itemBytes.length);
                     }
 
-                    concatenatedArrayEncodingBuffer.write(
-                            arrayItemEncoding, 0, arrayItemEncoding.length);
+                    byte[] dynamicBytes = dynamicBuffer.toByteArray();
+                    dynamicData.add(dynamicBytes);
+                    // Update total size of dynamic data
+                    dynamicDataSize += dynamicBytes.length;
+                } else {
+                    // Handle other types of arrays
+                    ByteArrayOutputStream concatenatedArrayEncodingBuffer =
+                            new ByteArrayOutputStream();
+                    for (Object arrayItem : arrayItems) {
+                        byte[] arrayItemEncoding;
+                        if (types.containsKey(baseTypeName)) {
+                            arrayItemEncoding =
+                                    sha3(
+                                            encodeData(
+                                                    baseTypeName,
+                                                    (HashMap<String, Object>) arrayItem));
+                        } else {
+                            arrayItemEncoding = convertToEncodedItem(baseTypeName, arrayItem);
+                        }
+                        concatenatedArrayEncodingBuffer.write(
+                                arrayItemEncoding, 0, arrayItemEncoding.length);
+                    }
+                    byte[] concatenatedArrayEncodings =
+                            concatenatedArrayEncodingBuffer.toByteArray();
+                    byte[] hashedValue = sha3(concatenatedArrayEncodings);
+                    encTypes.add("bytes32");
+                    encValues.add(hashedValue);
                 }
-
-                byte[] concatenatedArrayEncodings = concatenatedArrayEncodingBuffer.toByteArray();
-                byte[] hashedValue = sha3(concatenatedArrayEncodings);
-                encTypes.add("bytes32");
-                encValues.add(hashedValue);
             } else if (field.getType().startsWith("uint") || field.getType().startsWith("int")) {
                 encTypes.add(field.getType());
-                // convert to BigInteger for ABI constructor compatibility
                 try {
                     encValues.add(convertToBigInt(value));
                 } catch (NumberFormatException | NullPointerException e) {
-                    encValues.add(
-                            value); // value null or failed to convert, fallback to add string as
-                    // before
+                    encValues.add(value);
                 }
             } else {
                 encTypes.add(field.getType());
@@ -380,41 +415,50 @@ public class StructuredDataEncoder {
             }
         }
 
+        // Write all data
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        for (int i = 0; i < encTypes.size(); i++) {
-            Class<Type> typeClazz = (Class<Type>) AbiTypes.getType(encTypes.get(i));
 
-            boolean atleastOneConstructorExistsForGivenParametersType = false;
-            // Using the Reflection API to get the types of the parameters
-            Constructor[] constructors = typeClazz.getConstructors();
-            for (Constructor constructor : constructors) {
-                // Check which constructor matches
-                try {
-                    Class[] parameterTypes = constructor.getParameterTypes();
-                    byte[] temp =
-                            Numeric.hexStringToByteArray(
-                                    TypeEncoder.encode(
-                                            typeClazz
-                                                    .getDeclaredConstructor(parameterTypes)
-                                                    .newInstance(encValues.get(i))));
-                    baos.write(temp, 0, temp.length);
-                    atleastOneConstructorExistsForGivenParametersType = true;
-                    break;
-                } catch (IllegalArgumentException
-                        | NoSuchMethodException
-                        | InstantiationException
-                        | IllegalAccessException
-                        | InvocationTargetException ignored) {
+        // Write header (static data and offsets)
+        for (int i = 0; i < encTypes.size(); i++) {
+            String type = encTypes.get(i);
+            Object value = encValues.get(i);
+
+            if (type.equals("bytes32")) {
+                if (value instanceof byte[]) {
+                    baos.write((byte[]) value, 0, ((byte[]) value).length);
+                } else {
+                    throw new RuntimeException("Expected byte[] for bytes32 type");
+                }
+            } else {
+                Class<Type> typeClazz = (Class<Type>) AbiTypes.getType(type);
+                Constructor[] constructors = typeClazz.getConstructors();
+                boolean encoded = false;
+
+                for (Constructor constructor : constructors) {
+                    try {
+                        Class[] parameterTypes = constructor.getParameterTypes();
+                        byte[] temp =
+                                Numeric.hexStringToByteArray(
+                                        TypeEncoder.encode(
+                                                typeClazz
+                                                        .getDeclaredConstructor(parameterTypes)
+                                                        .newInstance(value)));
+                        baos.write(temp, 0, temp.length);
+                        encoded = true;
+                        break;
+                    } catch (Exception ignored) {
+                    }
+                }
+
+                if (!encoded) {
+                    throw new RuntimeException("Failed to encode parameter");
                 }
             }
+        }
 
-            if (!atleastOneConstructorExistsForGivenParametersType) {
-                throw new RuntimeException(
-                        String.format(
-                                "Received an invalid argument for which no constructor"
-                                        + " exists for the ABI Class %s",
-                                typeClazz.getSimpleName()));
-            }
+        // Write dynamic data
+        for (byte[] dynamicBytes : dynamicData) {
+            baos.write(dynamicBytes, 0, dynamicBytes.length);
         }
 
         return baos.toByteArray();

--- a/crypto/src/test/java/org/web3j/crypto/StructuredDataEncoderTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/StructuredDataEncoderTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2025 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.crypto;
+
+import java.io.ByteArrayOutputStream;
+import java.util.HashMap;
+
+import org.junit.jupiter.api.Test;
+
+import org.web3j.utils.Numeric;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class StructuredDataEncoderTest {
+
+    @Test
+    public void testCustomEncodeData() throws Exception {
+
+        // json
+
+        String jsonMessage =
+                """
+                {
+                  "domain" : {
+                    "chainId" : "84532",
+                    "name" : "Test",
+                    "verifyingContract" : "0xe483dea6aa7d3831173379d81e5c08874f1042e7",
+                    "version" : "1.0.0"
+                  },
+                  "message" : {
+                    "amounts" : [ 0, 0 ],
+                    "to" : "0xe483dea6aa7d3831173379d81e5c08874f1042e7",
+                    "tokenIds" : [ 0, 1 ],
+                    "validityEndTimestamp" : 1743005854,
+                    "validityStartTimestamp" : 1742919454,
+                    "salt" : "82"
+                  },
+                  "primaryType" : "ClaimRequest",
+                  "types" : {
+                    "ClaimRequest" : [ {
+                      "name" : "to",
+                      "type" : "address"
+                    }, {
+                      "name" : "tokenIds",
+                      "type" : "uint256[]"
+                    }, {
+                      "name" : "amounts",
+                      "type" : "uint256[]"
+                    }, {
+                      "name" : "validityStartTimestamp",
+                      "type" : "uint128"
+                    }, {
+                      "name" : "validityEndTimestamp",
+                      "type" : "uint128"
+                    }, {
+                      "name" : "salt",
+                      "type" : "uint256"
+                    } ],
+                    "EIP712Domain" : [ {
+                      "name" : "name",
+                      "type" : "string"
+                    }, {
+                      "name" : "version",
+                      "type" : "string"
+                    }, {
+                      "name" : "chainId",
+                      "type" : "uint256"
+                    }, {
+                      "name" : "verifyingContract",
+                      "type" : "address"
+                    } ]
+                  }
+                }
+                """;
+
+        System.out.println("JSON Message: " + jsonMessage);
+
+        // struct instance
+        StructuredDataEncoder encoder = new StructuredDataEncoder(jsonMessage);
+        encoder.hashStructuredData();
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+        byte[] dataHash =
+                encoder.encodeData(
+                        encoder.jsonMessageObject.getPrimaryType(),
+                        (HashMap<String, Object>) encoder.jsonMessageObject.getMessage());
+        System.out.println("################ hash is " + Numeric.toHexString(dataHash));
+        baos.write(dataHash, 0, dataHash.length);
+    }
+}


### PR DESCRIPTION
# Dynamic Array Encoding Fix in Web3j

## Problem Statement
The original implementation did not correctly handle dynamic arrays according to Solidity's ABI encoding specification. In Solidity, when using `abi.encode()` with array parameters, the output includes dynamic offsets pointing to the actual array data.

### Example in Solidity
```solidity
// Solidity contract
function encodeExample(uint256[] memory tokenIds, uint256[] memory amounts) public pure returns (bytes memory) {
    return abi.encode(tokenIds, amounts);
}
```

When calling this function with:
```javascript
tokenIds = [1, 2]
amounts = [100, 200, 300]
```

The encoded output structure should be:
```
[offset_1][offset_2][array1_length][array1_data...][array2_length][array2_data...]
```

## Issue
The original Web3j implementation was concatenating array data directly without proper offset handling:
```java
// Original problematic implementation
ByteArrayOutputStream concatenatedArrayEncodingBuffer = new ByteArrayOutputStream();
for (Object arrayItem : arrayItems) {
    // Directly writing array data without offsets
    concatenatedArrayEncodingBuffer.write(arrayItemEncoding, 0, arrayItemEncoding.length);
}
```

## Solution
Modified the implementation to follow Solidity's ABI encoding specification:
```java
// Fixed implementation
// 1. Calculate and write offsets in the header
encValues.add(BigInteger.valueOf(headSize + dynamicDataSize));

// 2. Store dynamic data separately
ByteArrayOutputStream dynamicBuffer = new ByteArrayOutputStream();
// Write array length
byte[] lengthBytes = Numeric.toBytesPadded(BigInteger.valueOf(arrayItems.size()), 32);
dynamicBuffer.write(lengthBytes, 0, lengthBytes.length);
// Write array elements
for (Object arrayItem : arrayItems) {
    byte[] itemBytes = Numeric.toBytesPadded(convertToBigInt(arrayItem), 32);
    dynamicBuffer.write(itemBytes, 0, itemBytes.length);
}
```

## Impact
- Ensures compatibility with Solidity's `abi.encode()` function
- Fixes signature verification issues in contracts using EIP-712
- Correctly handles multiple dynamic arrays in structured data

This change aligns Web3j's implementation with Ethereum's ABI specification for dynamic array encoding.
