### PR TITLE
Fix broken Code of Conduct URL

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-# [Hyperledger Code of Conduct](https://wiki.hyperledger.org/community/hyperledger-project-code-of-conduct)
+# [Hyperledger Code of Conduct](https://lf-hyperledger.atlassian.net/wiki/spaces/HYP/pages/19595281/Hyperledger+Code+of+Conduct)
 
 Hyperledger is a collaborative project at The Linux Foundation. It is an open-source and open
 community project where participants choose to work together, and in that process experience


### PR DESCRIPTION
🔁 Word Replacement:
Old link:
https://wiki.hyperledger.org/community/hyperledger-project-code-of-conduct

New link:
https://lf-hyperledger.atlassian.net/wiki/spaces/HYP/pages/19595281/Hyperledger+Code+of+Conduct


The previous hyperlink to the Hyperledger Code of Conduct was outdated and no longer valid.
We updated the URL to point to the official and current Atlassian-hosted wiki page.
This ensures that contributors are directed to the correct and accessible documentation.