### PR TITLE
feat: 7702 decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ### Features
 
 * bump snapshot version to 4.14.1 [#2176](https://github.com/hyperledger-web3j/web3j/pull/2176)
+* add encoding/decoding for EIP-7702 transactions [#2178](https://github.com/LFDT-web3j/web3j/pull/2178)
 
 ### BREAKING CHANGES
 

--- a/crypto/src/main/java/org/web3j/crypto/AuthorizationTuple.java
+++ b/crypto/src/main/java/org/web3j/crypto/AuthorizationTuple.java
@@ -1,0 +1,53 @@
+package org.web3j.crypto;
+
+import java.math.BigInteger;
+
+public class AuthorizationTuple {
+    private final BigInteger chainId;
+    private final String address;
+    private final BigInteger nonce;
+    private final BigInteger yParity;
+    private final BigInteger r;
+    private final BigInteger s;
+
+    public AuthorizationTuple(
+        BigInteger chainId,
+        String address,
+        BigInteger nonce,
+        BigInteger yParity,
+        BigInteger r,
+        BigInteger s
+    ) {
+        this.chainId = chainId;
+        this.address = address;
+        this.nonce = nonce;
+        this.yParity = yParity;
+        this.r = r;
+        this.s = s;
+    }
+    
+    public BigInteger getChainId() {
+        return chainId;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public BigInteger getNonce() {
+        return nonce;
+    }
+
+    public BigInteger getYParity() {
+        return yParity;
+    }
+
+    public BigInteger getR() {
+        return r;
+    }
+
+    public BigInteger getS() {
+        return s;
+    }
+
+}

--- a/crypto/src/main/java/org/web3j/crypto/AuthorizationTuple.java
+++ b/crypto/src/main/java/org/web3j/crypto/AuthorizationTuple.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2025 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package org.web3j.crypto;
 
 import java.math.BigInteger;
@@ -12,13 +24,12 @@ public class AuthorizationTuple {
     private final BigInteger s;
 
     public AuthorizationTuple(
-        BigInteger chainId,
-        String address,
-        BigInteger nonce,
-        BigInteger yParity,
-        BigInteger r,
-        BigInteger s
-    ) {
+            BigInteger chainId,
+            String address,
+            BigInteger nonce,
+            BigInteger yParity,
+            BigInteger r,
+            BigInteger s) {
         this.chainId = chainId;
         this.address = address;
         this.nonce = nonce;

--- a/crypto/src/main/java/org/web3j/crypto/AuthorizationTuple.java
+++ b/crypto/src/main/java/org/web3j/crypto/AuthorizationTuple.java
@@ -1,6 +1,7 @@
 package org.web3j.crypto;
 
 import java.math.BigInteger;
+import java.util.Objects;
 
 public class AuthorizationTuple {
     private final BigInteger chainId;
@@ -25,7 +26,7 @@ public class AuthorizationTuple {
         this.r = r;
         this.s = s;
     }
-    
+
     public BigInteger getChainId() {
         return chainId;
     }
@@ -50,4 +51,21 @@ public class AuthorizationTuple {
         return s;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;          // same object in memory
+        if (!(o instanceof AuthorizationTuple)) return false;
+        AuthorizationTuple that = (AuthorizationTuple) o;
+        return Objects.equals(chainId, that.chainId)
+                && Objects.equals(address, that.address)
+                && Objects.equals(nonce, that.nonce)
+                && Objects.equals(yParity, that.yParity)
+                && Objects.equals(r, that.r)
+                && Objects.equals(s, that.s);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(chainId, address, nonce, yParity, r, s);
+    }
 }

--- a/crypto/src/main/java/org/web3j/crypto/AuthorizationTuple.java
+++ b/crypto/src/main/java/org/web3j/crypto/AuthorizationTuple.java
@@ -53,7 +53,7 @@ public class AuthorizationTuple {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;          // same object in memory
+        if (this == o) return true;
         if (!(o instanceof AuthorizationTuple)) return false;
         AuthorizationTuple that = (AuthorizationTuple) o;
         return Objects.equals(chainId, that.chainId)

--- a/crypto/src/main/java/org/web3j/crypto/RawTransaction.java
+++ b/crypto/src/main/java/org/web3j/crypto/RawTransaction.java
@@ -23,6 +23,7 @@ import org.web3j.crypto.transaction.type.LegacyTransaction;
 import org.web3j.crypto.transaction.type.Transaction1559;
 import org.web3j.crypto.transaction.type.Transaction2930;
 import org.web3j.crypto.transaction.type.Transaction4844;
+import org.web3j.crypto.transaction.type.Transaction7702;
 import org.web3j.crypto.transaction.type.TransactionType;
 
 /**
@@ -244,6 +245,33 @@ public class RawTransaction {
                 Transaction2930.createTransaction(
                         chainId, nonce, gasPrice, gasLimit, to, value, data, accessList));
     }
+
+    public static RawTransaction createTransactionEIP7702(
+        long chainId,
+        BigInteger nonce,
+        BigInteger maxPriorityFeePerGas,
+        BigInteger maxFeePerGas,
+        BigInteger gasLimit,
+        String to,
+        BigInteger value,
+        String data,
+        List<AccessListObject> accessList,
+        List<AuthorizationTuple> authorizationList
+) {
+    Transaction7702 tx = Transaction7702.createTransaction(
+            chainId,
+            nonce,
+            maxPriorityFeePerGas,
+            maxFeePerGas,
+            gasLimit,
+            to,
+            value,
+            data,
+            accessList,
+            authorizationList
+    );
+    return new RawTransaction(tx);
+}
 
     public BigInteger getNonce() {
         return transaction.getNonce();

--- a/crypto/src/main/java/org/web3j/crypto/RawTransaction.java
+++ b/crypto/src/main/java/org/web3j/crypto/RawTransaction.java
@@ -246,7 +246,7 @@ public class RawTransaction {
                         chainId, nonce, gasPrice, gasLimit, to, value, data, accessList));
     }
 
-    public static RawTransaction createTransactionEIP7702(
+    public static RawTransaction createTransaction(
         long chainId,
         BigInteger nonce,
         BigInteger maxPriorityFeePerGas,
@@ -258,19 +258,18 @@ public class RawTransaction {
         List<AccessListObject> accessList,
         List<AuthorizationTuple> authorizationList
 ) {
-    Transaction7702 tx = Transaction7702.createTransaction(
-            chainId,
-            nonce,
-            maxPriorityFeePerGas,
-            maxFeePerGas,
-            gasLimit,
-            to,
-            value,
-            data,
-            accessList,
-            authorizationList
-    );
-    return new RawTransaction(tx);
+    return new RawTransaction(
+            Transaction7702.createTransaction(
+                    chainId,
+                    nonce,
+                    maxPriorityFeePerGas,
+                    maxFeePerGas,
+                    gasLimit,
+                    to,
+                    value,
+                    data,
+                    accessList,
+                    authorizationList));
 }
 
     public BigInteger getNonce() {

--- a/crypto/src/main/java/org/web3j/crypto/RawTransaction.java
+++ b/crypto/src/main/java/org/web3j/crypto/RawTransaction.java
@@ -247,30 +247,29 @@ public class RawTransaction {
     }
 
     public static RawTransaction createTransaction(
-        long chainId,
-        BigInteger nonce,
-        BigInteger maxPriorityFeePerGas,
-        BigInteger maxFeePerGas,
-        BigInteger gasLimit,
-        String to,
-        BigInteger value,
-        String data,
-        List<AccessListObject> accessList,
-        List<AuthorizationTuple> authorizationList
-) {
-    return new RawTransaction(
-            Transaction7702.createTransaction(
-                    chainId,
-                    nonce,
-                    maxPriorityFeePerGas,
-                    maxFeePerGas,
-                    gasLimit,
-                    to,
-                    value,
-                    data,
-                    accessList,
-                    authorizationList));
-}
+            long chainId,
+            BigInteger nonce,
+            BigInteger maxPriorityFeePerGas,
+            BigInteger maxFeePerGas,
+            BigInteger gasLimit,
+            String to,
+            BigInteger value,
+            String data,
+            List<AccessListObject> accessList,
+            List<AuthorizationTuple> authorizationList) {
+        return new RawTransaction(
+                Transaction7702.createTransaction(
+                        chainId,
+                        nonce,
+                        maxPriorityFeePerGas,
+                        maxFeePerGas,
+                        gasLimit,
+                        to,
+                        value,
+                        data,
+                        accessList,
+                        authorizationList));
+    }
 
     public BigInteger getNonce() {
         return transaction.getNonce();

--- a/crypto/src/main/java/org/web3j/crypto/TransactionDecoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/TransactionDecoder.java
@@ -32,6 +32,7 @@ public class TransactionDecoder {
     private static final int UNSIGNED_EIP1559TX_RLP_LIST_SIZE = 9;
     private static final int UNSIGNED_EIP2930TX_RLP_LIST_SIZE = 8;
     private static final int UNSIGNED_EIP4844TX_RLP_LIST_SIZE = 11;
+    private static final int UNSIGNED_EIP7702TX_RLP_LIST_SIZE = 10;
 
     public static RawTransaction decode(final String hexTransaction) {
         final byte[] transaction = Numeric.hexStringToByteArray(hexTransaction);
@@ -44,8 +45,110 @@ public class TransactionDecoder {
                 return decodeEIP4844Transaction(transaction);
             case EIP2930:
                 return decodeEIP2930Transaction(transaction);
+            case EIP7702:
+                return decodeEIP7702Transaction(transaction);
             default:
                 return decodeLegacyTransaction(transaction);
+        }
+    }
+
+    private static RawTransaction decodeEIP7702Transaction(final byte[] transaction) {
+        // Strip off the type byte (0x04) before decoding the RLP list
+        final byte[] encodedTx = Arrays.copyOfRange(transaction, 1, transaction.length);
+        final RlpList rlpList = RlpDecoder.decode(encodedTx);
+        final RlpList values = (RlpList) rlpList.getValues().get(0);
+        final List<RlpType> fields = values.getValues();
+    
+        // 0. chain_id
+        final long chainId =
+            ((RlpString) fields.get(0)).asPositiveBigInteger().longValue();
+    
+        // 1. nonce
+        final BigInteger nonce =
+            ((RlpString) fields.get(1)).asPositiveBigInteger();
+    
+        // 2. max_priority_fee_per_gas
+        final BigInteger maxPriorityFeePerGas =
+            ((RlpString) fields.get(2)).asPositiveBigInteger();
+    
+        // 3. max_fee_per_gas
+        final BigInteger maxFeePerGas =
+            ((RlpString) fields.get(3)).asPositiveBigInteger();
+    
+        // 4. gas_limit
+        final BigInteger gasLimit =
+            ((RlpString) fields.get(4)).asPositiveBigInteger();
+    
+        // 5. destination (EIP-7702 forbids a null/empty 'to', but you can decide how to handle that)
+        final String to =
+            ((RlpString) fields.get(5)).asString();
+    
+        // 6. value
+        final BigInteger value =
+            ((RlpString) fields.get(6)).asPositiveBigInteger();
+    
+        // 7. data
+        final String data =
+            ((RlpString) fields.get(7)).asString();
+    
+        // 8. access_list (same decoding logic you already have)
+        final List<RlpType> accessListRlp =
+            ((RlpList) fields.get(8)).getValues();
+        final List<AccessListObject> accessList = decodeAccessList(accessListRlp);
+    
+        // 9. authorization_list
+        final List<AuthorizationTuple> authorizationList =
+            decodeAuthorizationList(((RlpList) fields.get(9)).getValues());
+        // The EIP states that an empty authorization list (size=0) is invalid,
+        // but you can choose to handle that or let it fail in validation later.
+    
+        // Construct the raw transaction
+        final RawTransaction rawTransaction =
+            RawTransaction.createTransactionEIP7702(
+                chainId,
+                nonce,
+                maxPriorityFeePerGas,
+                maxFeePerGas,
+                gasLimit,
+                to,
+                value,
+                data,
+                accessList,
+                authorizationList
+            );
+    
+        // Check if signature fields are present
+        if (fields.size() == UNSIGNED_EIP7702TX_RLP_LIST_SIZE) {
+            // No signature => return as-is
+            return rawTransaction;
+        } else {
+            // 10. signature_y_parity
+            final int yParity =
+                Numeric.toBigInt(((RlpString) fields.get(10)).getBytes()).intValue();
+    
+            // 11. signature_r
+            final byte[] rBytes =
+                Numeric.toBytesPadded(
+                    Numeric.toBigInt(((RlpString) fields.get(11)).getBytes()),
+                    32
+                );
+    
+            // 12. signature_s
+            final byte[] sBytes =
+                Numeric.toBytesPadded(
+                    Numeric.toBigInt(((RlpString) fields.get(12)).getBytes()),
+                    32
+                );
+    
+            // Convert y_parity into an ECDSA V value
+            final byte[] vBytes = Sign.getVFromRecId(yParity);
+    
+            // Build the signature data object
+            final Sign.SignatureData signatureData =
+                new Sign.SignatureData(vBytes, rBytes, sBytes);
+    
+            // Wrap the raw transaction in a SignedRawTransaction
+            return new SignedRawTransaction(rawTransaction.getTransaction(), signatureData);
         }
     }
 
@@ -55,6 +158,7 @@ public class TransactionDecoder {
         if (firstByte == TransactionType.EIP1559.getRlpType()) return TransactionType.EIP1559;
         else if (firstByte == TransactionType.EIP4844.getRlpType()) return TransactionType.EIP4844;
         else if (firstByte == TransactionType.EIP2930.getRlpType()) return TransactionType.EIP2930;
+        else if (firstByte == TransactionType.EIP7702.getRlpType()) return TransactionType.EIP7702;
         else return TransactionType.LEGACY;
     }
 
@@ -288,5 +392,30 @@ public class TransactionDecoder {
                             }
                         })
                 .collect(Collectors.toList());
+    }
+
+    private static List<AuthorizationTuple> decodeAuthorizationList(final List<RlpType> rlpList) {
+        return rlpList.stream()
+            .map(item -> (RlpList) item) // each authorization tuple is an RlpList
+            .map(tuple -> {
+                final List<RlpType> elements = tuple.getValues();
+                final BigInteger authChainId = ((RlpString) elements.get(0)).asPositiveBigInteger();
+                final String address = ((RlpString) elements.get(1)).asString();
+                final BigInteger authNonce = ((RlpString) elements.get(2)).asPositiveBigInteger();
+                final BigInteger yParity = ((RlpString) elements.get(3)).asPositiveBigInteger();
+                final BigInteger rValue = ((RlpString) elements.get(4)).asPositiveBigInteger();
+                final BigInteger sValue = ((RlpString) elements.get(5)).asPositiveBigInteger();
+    
+                // Convert or store them as desired; for example:
+                return new AuthorizationTuple(
+                    authChainId,
+                    address,
+                    authNonce,
+                    yParity,
+                    rValue,
+                    sValue
+                );
+            })
+            .collect(Collectors.toList());
     }
 }

--- a/crypto/src/main/java/org/web3j/crypto/TransactionDecoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/TransactionDecoder.java
@@ -58,66 +58,51 @@ public class TransactionDecoder {
         final RlpList rlpList = RlpDecoder.decode(encodedTx);
         final RlpList values = (RlpList) rlpList.getValues().get(0);
         final List<RlpType> fields = values.getValues();
-    
-        final long chainId =
-            ((RlpString) fields.get(0)).asPositiveBigInteger().longValue();
-        final BigInteger nonce =
-            ((RlpString) fields.get(1)).asPositiveBigInteger();
-        final BigInteger maxPriorityFeePerGas =
-            ((RlpString) fields.get(2)).asPositiveBigInteger();
-        final BigInteger maxFeePerGas =
-            ((RlpString) fields.get(3)).asPositiveBigInteger();
-        final BigInteger gasLimit =
-            ((RlpString) fields.get(4)).asPositiveBigInteger();
-        final String to =
-            ((RlpString) fields.get(5)).asString();
-        final BigInteger value =
-            ((RlpString) fields.get(6)).asPositiveBigInteger();
-        final String data =
-            ((RlpString) fields.get(7)).asString();
-        final List<RlpType> accessListRlp =
-            ((RlpList) fields.get(8)).getValues();
+
+        final long chainId = ((RlpString) fields.get(0)).asPositiveBigInteger().longValue();
+        final BigInteger nonce = ((RlpString) fields.get(1)).asPositiveBigInteger();
+        final BigInteger maxPriorityFeePerGas = ((RlpString) fields.get(2)).asPositiveBigInteger();
+        final BigInteger maxFeePerGas = ((RlpString) fields.get(3)).asPositiveBigInteger();
+        final BigInteger gasLimit = ((RlpString) fields.get(4)).asPositiveBigInteger();
+        final String to = ((RlpString) fields.get(5)).asString();
+        final BigInteger value = ((RlpString) fields.get(6)).asPositiveBigInteger();
+        final String data = ((RlpString) fields.get(7)).asString();
+        final List<RlpType> accessListRlp = ((RlpList) fields.get(8)).getValues();
         final List<AccessListObject> accessList = decodeAccessList(accessListRlp);
         final List<AuthorizationTuple> authorizationList =
-            decodeAuthorizationList(((RlpList) fields.get(9)).getValues());
+                decodeAuthorizationList(((RlpList) fields.get(9)).getValues());
         // INV: Per the EIP, authorization list should be nonempty. We don't
         // enforce that here.
-    
+
         final RawTransaction rawTransaction =
-            RawTransaction.createTransaction(
-                chainId,
-                nonce,
-                maxPriorityFeePerGas,
-                maxFeePerGas,
-                gasLimit,
-                to,
-                value,
-                data,
-                accessList,
-                authorizationList
-            );
-    
+                RawTransaction.createTransaction(
+                        chainId,
+                        nonce,
+                        maxPriorityFeePerGas,
+                        maxFeePerGas,
+                        gasLimit,
+                        to,
+                        value,
+                        data,
+                        accessList,
+                        authorizationList);
+
         if (fields.size() == UNSIGNED_EIP7702TX_RLP_LIST_SIZE) {
             return rawTransaction;
         } else {
             final int yParity =
-                Numeric.toBigInt(((RlpString) fields.get(10)).getBytes()).intValue();
+                    Numeric.toBigInt(((RlpString) fields.get(10)).getBytes()).intValue();
             final byte[] rBytes =
-                Numeric.toBytesPadded(
-                    Numeric.toBigInt(((RlpString) fields.get(11)).getBytes()),
-                    32
-                );
+                    Numeric.toBytesPadded(
+                            Numeric.toBigInt(((RlpString) fields.get(11)).getBytes()), 32);
             final byte[] sBytes =
-                Numeric.toBytesPadded(
-                    Numeric.toBigInt(((RlpString) fields.get(12)).getBytes()),
-                    32
-                );
-    
+                    Numeric.toBytesPadded(
+                            Numeric.toBigInt(((RlpString) fields.get(12)).getBytes()), 32);
+
             final byte[] vBytes = Sign.getVFromRecId(yParity);
-    
-            final Sign.SignatureData signatureData =
-                new Sign.SignatureData(vBytes, rBytes, sBytes);
-    
+
+            final Sign.SignatureData signatureData = new Sign.SignatureData(vBytes, rBytes, sBytes);
+
             return new SignedRawTransaction(rawTransaction.getTransaction(), signatureData);
         }
     }
@@ -366,26 +351,26 @@ public class TransactionDecoder {
 
     private static List<AuthorizationTuple> decodeAuthorizationList(final List<RlpType> rlpList) {
         return rlpList.stream()
-            .map(item -> (RlpList) item) // each authorization tuple is an RlpList
-            .map(tuple -> {
-                final List<RlpType> elements = tuple.getValues();
-                final BigInteger authChainId = ((RlpString) elements.get(0)).asPositiveBigInteger();
-                final String address = ((RlpString) elements.get(1)).asString();
-                final BigInteger authNonce = ((RlpString) elements.get(2)).asPositiveBigInteger();
-                final BigInteger yParity = ((RlpString) elements.get(3)).asPositiveBigInteger();
-                final BigInteger rValue = ((RlpString) elements.get(4)).asPositiveBigInteger();
-                final BigInteger sValue = ((RlpString) elements.get(5)).asPositiveBigInteger();
-    
-                // Convert or store them as desired; for example:
-                return new AuthorizationTuple(
-                    authChainId,
-                    address,
-                    authNonce,
-                    yParity,
-                    rValue,
-                    sValue
-                );
-            })
-            .collect(Collectors.toList());
+                .map(item -> (RlpList) item) // each authorization tuple is an RlpList
+                .map(
+                        tuple -> {
+                            final List<RlpType> elements = tuple.getValues();
+                            final BigInteger authChainId =
+                                    ((RlpString) elements.get(0)).asPositiveBigInteger();
+                            final String address = ((RlpString) elements.get(1)).asString();
+                            final BigInteger authNonce =
+                                    ((RlpString) elements.get(2)).asPositiveBigInteger();
+                            final BigInteger yParity =
+                                    ((RlpString) elements.get(3)).asPositiveBigInteger();
+                            final BigInteger rValue =
+                                    ((RlpString) elements.get(4)).asPositiveBigInteger();
+                            final BigInteger sValue =
+                                    ((RlpString) elements.get(5)).asPositiveBigInteger();
+
+                            // Convert or store them as desired; for example:
+                            return new AuthorizationTuple(
+                                    authChainId, address, authNonce, yParity, rValue, sValue);
+                        })
+                .collect(Collectors.toList());
     }
 }

--- a/crypto/src/main/java/org/web3j/crypto/TransactionDecoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/TransactionDecoder.java
@@ -104,7 +104,7 @@ public class TransactionDecoder {
     
         // Construct the raw transaction
         final RawTransaction rawTransaction =
-            RawTransaction.createTransactionEIP7702(
+            RawTransaction.createTransaction(
                 chainId,
                 nonce,
                 maxPriorityFeePerGas,

--- a/crypto/src/main/java/org/web3j/crypto/TransactionEncoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/TransactionEncoder.java
@@ -124,7 +124,8 @@ public class TransactionEncoder {
 
         if (rawTransaction.getType().isEip1559()
                 || rawTransaction.getType().isEip2930()
-                || rawTransaction.getType().isEip4844()) {
+                || rawTransaction.getType().isEip4844()
+                || rawTransaction.getType().isEip7702()) {
             return ByteBuffer.allocate(encoded.length + 1)
                     .put(rawTransaction.getType().getRlpType())
                     .put(encoded)

--- a/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction7702.java
+++ b/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction7702.java
@@ -1,11 +1,22 @@
+/*
+ * Copyright 2025 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package org.web3j.crypto.transaction.type;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
-import org.apache.tuweni.bytes.Bytes;
 import org.web3j.crypto.AccessListObject;
 import org.web3j.crypto.AuthorizationTuple;
 import org.web3j.crypto.Sign;
@@ -14,22 +25,10 @@ import org.web3j.rlp.RlpString;
 import org.web3j.rlp.RlpType;
 import org.web3j.utils.Numeric;
 
-/**
- * Example EIP-7702 transaction class that extends EIP-1559–style transactions,
- * adding an authorizationList field.
- *
- * The EIP-7702 spec calls for:
- *   [chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit,
- *    destination, value, data, access_list, authorization_list,
- *    signature_y_parity, signature_r, signature_s]
- */
 public class Transaction7702 extends Transaction1559 implements ITransaction {
 
     private final List<AuthorizationTuple> authorizationList;
 
-    /**
-     * Minimal constructor (unsigned transaction).
-     */
     protected Transaction7702(
             long chainId,
             BigInteger nonce,
@@ -42,9 +41,7 @@ public class Transaction7702 extends Transaction1559 implements ITransaction {
             List<AccessListObject> accessList,
             List<AuthorizationTuple> authorizationList
     ) {
-        // Call the Transaction1559 constructor (which includes chainId, nonce, gasLimit, etc.)
         super(chainId, nonce, gasLimit, to, value, data, maxPriorityFeePerGas, maxFeePerGas);
-
         this.authorizationList = authorizationList;
     }
 
@@ -55,62 +52,32 @@ public class Transaction7702 extends Transaction1559 implements ITransaction {
         // gas_limit, to, value, data, access_list, authorization_list,
         // y_parity, r, s
         List<RlpType> values = new ArrayList<>();
-
-        // 0. chainId
         values.add(RlpString.create(getChainId()));
-
-        // 1. nonce
         values.add(RlpString.create(getNonce()));
-
-        // 2. max_priority_fee_per_gas
         values.add(RlpString.create(getMaxPriorityFeePerGas()));
-
-        // 3. max_fee_per_gas
         values.add(RlpString.create(getMaxFeePerGas()));
-
-        // 4. gas_limit
         values.add(RlpString.create(getGasLimit()));
-
-        // 5. to
         final String to = getTo();
         if (to != null && !to.isEmpty()) {
             values.add(RlpString.create(Numeric.hexStringToByteArray(to)));
         } else {
             values.add(RlpString.create(""));
         }
-
-        // 6. value
         values.add(RlpString.create(getValue()));
-
-        // 7. data
         byte[] dataBytes = Numeric.hexStringToByteArray(getData());
         values.add(RlpString.create(dataBytes));
-
-        // 8. access_list
-        // In Transaction1559 you might have a method getAccessList()
-        List<RlpType> accessListRlp = convertAccessListToRlp(getAccessList());
+        List<RlpType> accessListRlp = rlpAccessListRlp();
         values.add(new RlpList(accessListRlp));
-
-        // 9. authorization_list
-        // convert each AuthorizationTuple to RLP
         List<RlpType> authorizationRlp = convertAuthorizationListToRlp(authorizationList);
         values.add(new RlpList(authorizationRlp));
-
-        // If we have a signature, add y_parity, r, s:
         if (signatureData != null) {
-            // EIP-7702 uses y_parity in place of a normal "v"
-            // For EVM compatibility, we can store it similarly to how 1559 does:
             int recId = Sign.getRecId(signatureData, getChainId());
             values.add(RlpString.create(recId));  // y_parity
-
-            // r
             values.add(
                     RlpString.create(
                             org.web3j.utils.Bytes.trimLeadingZeroes(signatureData.getR())
                     )
             );
-
-            // s
             values.add(
                     RlpString.create(
                             org.web3j.utils.Bytes.trimLeadingZeroes(signatureData.getS())
@@ -118,41 +85,11 @@ public class Transaction7702 extends Transaction1559 implements ITransaction {
             );
         }
 
-        // Finally, wrap the entire list in an RlpList if your encoder expects that
         List<RlpType> wrapped = new ArrayList<>();
         wrapped.add(new RlpList(values));
         return wrapped;
     }
 
-    /**
-     * Helper to convert the EIP-2930/EIP-1559 access list to RLP.
-     */
-    private List<RlpType> convertAccessListToRlp(List<AccessListObject> accessList) {
-        List<RlpType> result = new ArrayList<>();
-        if (accessList != null) {
-            for (AccessListObject entry : accessList) {
-                // Each item is [address, [storageKeys...]]
-                List<RlpType> entryRlp = new ArrayList<>();
-                byte[] addressBytes = Numeric.hexStringToByteArray(entry.getAddress());
-                entryRlp.add(RlpString.create(addressBytes));
-
-                // storageKeys
-                List<RlpType> storageKeys = new ArrayList<>();
-                for (String sk : entry.getStorageKeys()) {
-                    storageKeys.add(RlpString.create(Numeric.hexStringToByteArray(sk)));
-                }
-                entryRlp.add(new RlpList(storageKeys));
-
-                result.add(new RlpList(entryRlp));
-            }
-        }
-        return result;
-    }
-
-    /**
-     * Convert EIP-7702's authorization_list to RLP: each tuple is
-     * [authChainId, address, authNonce, y_parity, r, s].
-     */
     private List<RlpType> convertAuthorizationListToRlp(List<AuthorizationTuple> authList) {
         List<RlpType> result = new ArrayList<>();
         if (authList == null) {
@@ -173,7 +110,7 @@ public class Transaction7702 extends Transaction1559 implements ITransaction {
 
     @Override
     public TransactionType getType() {
-        return TransactionType.EIP7702;  // Make sure your enum has EIP7702
+        return TransactionType.EIP7702;
     }
 
     /**

--- a/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction7702.java
+++ b/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction7702.java
@@ -38,8 +38,7 @@ public class Transaction7702 extends Transaction1559 implements ITransaction {
             BigInteger value,
             String data,
             List<AccessListObject> accessList,
-            List<AuthorizationTuple> authorizationList
-    ) {
+            List<AuthorizationTuple> authorizationList) {
         super(chainId, nonce, gasLimit, to, value, data, maxPriorityFeePerGas, maxFeePerGas);
         this.authorizationList = authorizationList;
     }
@@ -71,17 +70,13 @@ public class Transaction7702 extends Transaction1559 implements ITransaction {
         values.add(new RlpList(authorizationRlp));
         if (signatureData != null) {
             int recId = Sign.getRecId(signatureData, getChainId());
-            values.add(RlpString.create(recId));  // y_parity
+            values.add(RlpString.create(recId)); // y_parity
             values.add(
                     RlpString.create(
-                            org.web3j.utils.Bytes.trimLeadingZeroes(signatureData.getR())
-                    )
-            );
+                            org.web3j.utils.Bytes.trimLeadingZeroes(signatureData.getR())));
             values.add(
                     RlpString.create(
-                            org.web3j.utils.Bytes.trimLeadingZeroes(signatureData.getS())
-                    )
-            );
+                            org.web3j.utils.Bytes.trimLeadingZeroes(signatureData.getS())));
         }
 
         List<RlpType> wrapped = new ArrayList<>();
@@ -122,8 +117,7 @@ public class Transaction7702 extends Transaction1559 implements ITransaction {
             BigInteger value,
             String data,
             List<AccessListObject> accessList,
-            List<AuthorizationTuple> authorizationList
-    ) {
+            List<AuthorizationTuple> authorizationList) {
         return new Transaction7702(
                 chainId,
                 nonce,
@@ -134,8 +128,7 @@ public class Transaction7702 extends Transaction1559 implements ITransaction {
                 value,
                 data,
                 accessList,
-                authorizationList
-        );
+                authorizationList);
     }
 
     public List<AuthorizationTuple> getAuthorizationList() {

--- a/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction7702.java
+++ b/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction7702.java
@@ -79,9 +79,7 @@ public class Transaction7702 extends Transaction1559 implements ITransaction {
                             org.web3j.utils.Bytes.trimLeadingZeroes(signatureData.getS())));
         }
 
-        List<RlpType> wrapped = new ArrayList<>();
-        wrapped.add(new RlpList(values));
-        return wrapped;
+        return values;
     }
 
     private List<RlpType> convertAuthorizationListToRlp(List<AuthorizationTuple> authList) {

--- a/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction7702.java
+++ b/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction7702.java
@@ -1,0 +1,211 @@
+package org.web3j.crypto.transaction.type;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.web3j.crypto.AccessListObject;
+import org.web3j.crypto.AuthorizationTuple;
+import org.web3j.crypto.Sign;
+import org.web3j.rlp.RlpList;
+import org.web3j.rlp.RlpString;
+import org.web3j.rlp.RlpType;
+import org.web3j.utils.Numeric;
+
+/**
+ * Example EIP-7702 transaction class that extends EIP-1559–style transactions,
+ * adding an authorizationList field.
+ *
+ * The EIP-7702 spec calls for:
+ *   [chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit,
+ *    destination, value, data, access_list, authorization_list,
+ *    signature_y_parity, signature_r, signature_s]
+ */
+public class Transaction7702 extends Transaction1559 implements ITransaction {
+
+    private final List<AuthorizationTuple> authorizationList;
+
+    /**
+     * Minimal constructor (unsigned transaction).
+     */
+    protected Transaction7702(
+            long chainId,
+            BigInteger nonce,
+            BigInteger maxPriorityFeePerGas,
+            BigInteger maxFeePerGas,
+            BigInteger gasLimit,
+            String to,
+            BigInteger value,
+            String data,
+            List<AccessListObject> accessList,
+            List<AuthorizationTuple> authorizationList
+    ) {
+        // Call the Transaction1559 constructor (which includes chainId, nonce, gasLimit, etc.)
+        super(chainId, nonce, gasLimit, to, value, data, maxPriorityFeePerGas, maxFeePerGas);
+
+        this.authorizationList = authorizationList;
+    }
+
+    @Override
+    public List<RlpType> asRlpValues(final Sign.SignatureData signatureData) {
+        // EIP-7702 fields in RLP order:
+        // chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
+        // gas_limit, to, value, data, access_list, authorization_list,
+        // y_parity, r, s
+        List<RlpType> values = new ArrayList<>();
+
+        // 0. chainId
+        values.add(RlpString.create(getChainId()));
+
+        // 1. nonce
+        values.add(RlpString.create(getNonce()));
+
+        // 2. max_priority_fee_per_gas
+        values.add(RlpString.create(getMaxPriorityFeePerGas()));
+
+        // 3. max_fee_per_gas
+        values.add(RlpString.create(getMaxFeePerGas()));
+
+        // 4. gas_limit
+        values.add(RlpString.create(getGasLimit()));
+
+        // 5. to
+        final String to = getTo();
+        if (to != null && !to.isEmpty()) {
+            values.add(RlpString.create(Numeric.hexStringToByteArray(to)));
+        } else {
+            values.add(RlpString.create(""));
+        }
+
+        // 6. value
+        values.add(RlpString.create(getValue()));
+
+        // 7. data
+        byte[] dataBytes = Numeric.hexStringToByteArray(getData());
+        values.add(RlpString.create(dataBytes));
+
+        // 8. access_list
+        // In Transaction1559 you might have a method getAccessList()
+        List<RlpType> accessListRlp = convertAccessListToRlp(getAccessList());
+        values.add(new RlpList(accessListRlp));
+
+        // 9. authorization_list
+        // convert each AuthorizationTuple to RLP
+        List<RlpType> authorizationRlp = convertAuthorizationListToRlp(authorizationList);
+        values.add(new RlpList(authorizationRlp));
+
+        // If we have a signature, add y_parity, r, s:
+        if (signatureData != null) {
+            // EIP-7702 uses y_parity in place of a normal "v"
+            // For EVM compatibility, we can store it similarly to how 1559 does:
+            int recId = Sign.getRecId(signatureData, getChainId());
+            values.add(RlpString.create(recId));  // y_parity
+
+            // r
+            values.add(
+                    RlpString.create(
+                            org.web3j.utils.Bytes.trimLeadingZeroes(signatureData.getR())
+                    )
+            );
+
+            // s
+            values.add(
+                    RlpString.create(
+                            org.web3j.utils.Bytes.trimLeadingZeroes(signatureData.getS())
+                    )
+            );
+        }
+
+        // Finally, wrap the entire list in an RlpList if your encoder expects that
+        List<RlpType> wrapped = new ArrayList<>();
+        wrapped.add(new RlpList(values));
+        return wrapped;
+    }
+
+    /**
+     * Helper to convert the EIP-2930/EIP-1559 access list to RLP.
+     */
+    private List<RlpType> convertAccessListToRlp(List<AccessListObject> accessList) {
+        List<RlpType> result = new ArrayList<>();
+        if (accessList != null) {
+            for (AccessListObject entry : accessList) {
+                // Each item is [address, [storageKeys...]]
+                List<RlpType> entryRlp = new ArrayList<>();
+                byte[] addressBytes = Numeric.hexStringToByteArray(entry.getAddress());
+                entryRlp.add(RlpString.create(addressBytes));
+
+                // storageKeys
+                List<RlpType> storageKeys = new ArrayList<>();
+                for (String sk : entry.getStorageKeys()) {
+                    storageKeys.add(RlpString.create(Numeric.hexStringToByteArray(sk)));
+                }
+                entryRlp.add(new RlpList(storageKeys));
+
+                result.add(new RlpList(entryRlp));
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Convert EIP-7702's authorization_list to RLP: each tuple is
+     * [authChainId, address, authNonce, y_parity, r, s].
+     */
+    private List<RlpType> convertAuthorizationListToRlp(List<AuthorizationTuple> authList) {
+        List<RlpType> result = new ArrayList<>();
+        if (authList == null) {
+            return result;
+        }
+        for (AuthorizationTuple at : authList) {
+            List<RlpType> tuple = new ArrayList<>();
+            tuple.add(RlpString.create(at.getChainId()));
+            tuple.add(RlpString.create(Numeric.hexStringToByteArray(at.getAddress())));
+            tuple.add(RlpString.create(at.getNonce()));
+            tuple.add(RlpString.create(at.getYParity()));
+            tuple.add(RlpString.create(at.getR()));
+            tuple.add(RlpString.create(at.getS()));
+            result.add(new RlpList(tuple));
+        }
+        return result;
+    }
+
+    @Override
+    public TransactionType getType() {
+        return TransactionType.EIP7702;  // Make sure your enum has EIP7702
+    }
+
+    /**
+     * Provide a static factory method to create an unsigned EIP-7702 transaction.
+     */
+    public static Transaction7702 createTransaction(
+            long chainId,
+            BigInteger nonce,
+            BigInteger maxPriorityFeePerGas,
+            BigInteger maxFeePerGas,
+            BigInteger gasLimit,
+            String to,
+            BigInteger value,
+            String data,
+            List<AccessListObject> accessList,
+            List<AuthorizationTuple> authorizationList
+    ) {
+        return new Transaction7702(
+                chainId,
+                nonce,
+                maxPriorityFeePerGas,
+                maxFeePerGas,
+                gasLimit,
+                to,
+                value,
+                data,
+                accessList,
+                authorizationList
+        );
+    }
+
+    public List<AuthorizationTuple> getAuthorizationList() {
+        return authorizationList;
+    }
+}

--- a/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction7702.java
+++ b/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction7702.java
@@ -10,7 +10,6 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-
 package org.web3j.crypto.transaction.type;
 
 import java.math.BigInteger;
@@ -113,9 +112,6 @@ public class Transaction7702 extends Transaction1559 implements ITransaction {
         return TransactionType.EIP7702;
     }
 
-    /**
-     * Provide a static factory method to create an unsigned EIP-7702 transaction.
-     */
     public static Transaction7702 createTransaction(
             long chainId,
             BigInteger nonce,

--- a/crypto/src/main/java/org/web3j/crypto/transaction/type/TransactionType.java
+++ b/crypto/src/main/java/org/web3j/crypto/transaction/type/TransactionType.java
@@ -44,4 +44,8 @@ public enum TransactionType {
     public boolean isEip4844() {
         return this.equals(TransactionType.EIP4844);
     }
+
+    public boolean isEip7702() {
+        return this.equals(TransactionType.EIP7702);
+    }
 }

--- a/crypto/src/main/java/org/web3j/crypto/transaction/type/TransactionType.java
+++ b/crypto/src/main/java/org/web3j/crypto/transaction/type/TransactionType.java
@@ -16,7 +16,8 @@ public enum TransactionType {
     LEGACY(null),
     EIP2930(((byte) 0x01)),
     EIP1559(((byte) 0x02)),
-    EIP4844(((byte) 0x03));
+    EIP4844(((byte) 0x03)),
+    EIP7702(((byte) 0x04));
 
     Byte type;
 

--- a/crypto/src/test/java/org/web3j/crypto/TransactionDecoderTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/TransactionDecoderTest.java
@@ -563,7 +563,7 @@ public class TransactionDecoderTest {
 
         final Sign.SignatureData sigData = signedDecoded.getSignatureData();
         final byte[] encodedNoSignature =
-                TransactionEncoder.encode(rawTransaction); // raw w/o the signature
+                TransactionEncoder.encode(rawTransaction);
         final BigInteger recoveredKey = Sign.signedMessageToKey(encodedNoSignature, sigData);
 
         assertEquals(SampleKeys.PUBLIC_KEY, recoveredKey);
@@ -573,8 +573,7 @@ public class TransactionDecoderTest {
     }
 
     private static RawTransaction createEip7702RawTransaction() {
-        // Example EIP-7702 data
-        long chainId = 42L; // e.g. "Kovan" style, but this is just for demonstration
+        long chainId = 42L;
         BigInteger nonce = BigInteger.valueOf(123);
         BigInteger maxPriorityFeePerGas = BigInteger.valueOf(5_000_000_000L);
         BigInteger maxFeePerGas = BigInteger.valueOf(30_000_000_000L);
@@ -600,7 +599,6 @@ public class TransactionDecoderTest {
                                 new BigInteger("111111111111111111111"),
                                 new BigInteger("222222222222222222222")));
 
-        // Create an EIP-7702 transaction via your new factory method in RawTransaction.
         return RawTransaction.createTransaction(
                 chainId,
                 nonce,

--- a/crypto/src/test/java/org/web3j/crypto/TransactionDecoderTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/TransactionDecoderTest.java
@@ -562,8 +562,7 @@ public class TransactionDecoderTest {
         assertNotNull(signedDecoded.getSignatureData());
 
         final Sign.SignatureData sigData = signedDecoded.getSignatureData();
-        final byte[] encodedNoSignature =
-                TransactionEncoder.encode(rawTransaction);
+        final byte[] encodedNoSignature = TransactionEncoder.encode(rawTransaction);
         final BigInteger recoveredKey = Sign.signedMessageToKey(encodedNoSignature, sigData);
 
         assertEquals(SampleKeys.PUBLIC_KEY, recoveredKey);

--- a/crypto/src/test/java/org/web3j/crypto/TransactionDecoderTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/TransactionDecoderTest.java
@@ -536,7 +536,8 @@ public class TransactionDecoderTest {
         final RawTransaction rawTransaction = createEip7702RawTransaction();
         final Transaction7702 tx7702 = (Transaction7702) rawTransaction.getTransaction();
 
-        final byte[] signedMessage = TransactionEncoder.signMessage(rawTransaction, SampleKeys.CREDENTIALS);
+        final byte[] signedMessage =
+                TransactionEncoder.signMessage(rawTransaction, SampleKeys.CREDENTIALS);
         final String signedHexMessage = Numeric.toHexString(signedMessage);
 
         final RawTransaction decodedRawTx = TransactionDecoder.decode(signedHexMessage);
@@ -561,7 +562,8 @@ public class TransactionDecoderTest {
         assertNotNull(signedDecoded.getSignatureData());
 
         final Sign.SignatureData sigData = signedDecoded.getSignatureData();
-        final byte[] encodedNoSignature = TransactionEncoder.encode(rawTransaction); // raw w/o the signature
+        final byte[] encodedNoSignature =
+                TransactionEncoder.encode(rawTransaction); // raw w/o the signature
         final BigInteger recoveredKey = Sign.signedMessageToKey(encodedNoSignature, sigData);
 
         assertEquals(SampleKeys.PUBLIC_KEY, recoveredKey);
@@ -572,7 +574,7 @@ public class TransactionDecoderTest {
 
     private static RawTransaction createEip7702RawTransaction() {
         // Example EIP-7702 data
-        long chainId = 42L;  // e.g. "Kovan" style, but this is just for demonstration
+        long chainId = 42L; // e.g. "Kovan" style, but this is just for demonstration
         BigInteger nonce = BigInteger.valueOf(123);
         BigInteger maxPriorityFeePerGas = BigInteger.valueOf(5_000_000_000L);
         BigInteger maxFeePerGas = BigInteger.valueOf(30_000_000_000L);
@@ -581,22 +583,22 @@ public class TransactionDecoderTest {
         BigInteger value = BigInteger.ZERO;
         String data = "0xdeadbeef";
 
-        List<AccessListObject> accessList = Collections.singletonList(
-            new AccessListObject(
-                "0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae",
-                Collections.singletonList("0x0000000000000000000000000000000000000000000000000000000000000003"))
-        );
+        List<AccessListObject> accessList =
+                Collections.singletonList(
+                        new AccessListObject(
+                                "0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae",
+                                Collections.singletonList(
+                                        "0x0000000000000000000000000000000000000000000000000000000000000003")));
 
-        List<AuthorizationTuple> authorizationList = Collections.singletonList(
-            new AuthorizationTuple(
-                BigInteger.valueOf(42),
-                "0xbaadf00d00000000000000000000000000000000",
-                BigInteger.TEN,
-                BigInteger.ONE,
-                new BigInteger("111111111111111111111"),
-                new BigInteger("222222222222222222222")
-            )
-        );
+        List<AuthorizationTuple> authorizationList =
+                Collections.singletonList(
+                        new AuthorizationTuple(
+                                BigInteger.valueOf(42),
+                                "0xbaadf00d00000000000000000000000000000000",
+                                BigInteger.TEN,
+                                BigInteger.ONE,
+                                new BigInteger("111111111111111111111"),
+                                new BigInteger("222222222222222222222")));
 
         // Create an EIP-7702 transaction via your new factory method in RawTransaction.
         return RawTransaction.createTransaction(
@@ -609,7 +611,6 @@ public class TransactionDecoderTest {
                 value,
                 data,
                 accessList,
-                authorizationList
-        );
+                authorizationList);
     }
 }


### PR DESCRIPTION
### What does this PR do?
Adds support for EIP-7702 transaction encoding/decoding

### Where should the reviewer start?
TransactionDecoder

### Why is it needed?
Support is missing for this transaction type. This PR allows the `TransactionDecoder` to handle all transaction types.

## Checklist

- [x] I've read the contribution guidelines.
- [x] I've added tests (if applicable).
- [x] I've added a changelog entry if necessary.