### PR TITLE
Dynamic array bug fix  2.  attempt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-* 
+* fix multidimensional array encoding [#1912](https://github.com/LFDT-web3j/web3j/issues/1912)
+
 ### Features
 
 * bump snapshot version to 4.14.1 [#2176](https://github.com/hyperledger-web3j/web3j/pull/2176)

--- a/abi/src/main/java/org/web3j/abi/datatypes/DynamicArray.java
+++ b/abi/src/main/java/org/web3j/abi/datatypes/DynamicArray.java
@@ -79,6 +79,8 @@ public class DynamicArray<T extends Type> extends Array<T> {
         } else {
             if (StructType.class.isAssignableFrom(value.get(0).getClass())) {
                 type = value.get(0).getTypeAsString();
+            } else if(DynamicArray.class.isAssignableFrom(value.get(0).getClass())) {
+                type = value.get(0).getTypeAsString();
             } else {
                 type = AbiTypes.getTypeAString(getComponentType());
             }

--- a/abi/src/test/java/org/web3j/abi/datatypes/DynamicArrayTest.java
+++ b/abi/src/test/java/org/web3j/abi/datatypes/DynamicArrayTest.java
@@ -13,12 +13,13 @@
 package org.web3j.abi.datatypes;
 
 import java.math.BigInteger;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.Test;
 
-import org.web3j.abi.Utils;
 import org.web3j.abi.datatypes.generated.Uint256;
 import org.web3j.abi.datatypes.generated.Uint8;
 

--- a/abi/src/test/java/org/web3j/abi/datatypes/DynamicArrayTest.java
+++ b/abi/src/test/java/org/web3j/abi/datatypes/DynamicArrayTest.java
@@ -54,9 +54,12 @@ public class DynamicArrayTest {
         List<List<BigInteger>> input = new ArrayList<>();
         DynamicArray<DynamicArray> array = new DynamicArray<>(
                 DynamicArray.class,
-                List.of(new DynamicArray<Uint256>(Uint256.class, new ArrayList<>()))
-       );
-        assertEquals( "uint256[][]", array.getTypeAsString());
+                List.of(new DynamicArray<DynamicArray>(
+                                DynamicArray.class,
+                                List.of(new DynamicArray<Uint256>(Uint256.class, new ArrayList<>()))
+                        )
+                ));
+        assertEquals("uint256[][][]", array.getTypeAsString());
     }
 
     private Uint[] arrayOfUints(int length) {

--- a/abi/src/test/java/org/web3j/abi/datatypes/DynamicArrayTest.java
+++ b/abi/src/test/java/org/web3j/abi/datatypes/DynamicArrayTest.java
@@ -12,12 +12,14 @@
  */
 package org.web3j.abi.datatypes;
 
-import java.util.Collections;
-import java.util.List;
+import java.math.BigInteger;
+import java.util.*;
 import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.Test;
 
+import org.web3j.abi.Utils;
+import org.web3j.abi.datatypes.generated.Uint256;
 import org.web3j.abi.datatypes.generated.Uint8;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -45,6 +47,16 @@ public class DynamicArrayTest {
         final DynamicArray<Uint> array = new DynamicArray<>(Uint.class, arrayOfUints(1));
 
         assertEquals(Uint.TYPE_NAME + "[]", array.getTypeAsString());
+    }
+
+    @Test
+    public void testMultidimensionalDynamicArray() {
+        List<List<BigInteger>> input = new ArrayList<>();
+        DynamicArray<DynamicArray> array = new DynamicArray<>(
+                DynamicArray.class,
+                List.of(new DynamicArray<Uint256>(Uint256.class, new ArrayList<>()))
+       );
+        assertEquals( "uint256[][]", array.getTypeAsString());
     }
 
     private Uint[] arrayOfUints(int length) {

--- a/abi/src/test/java/org/web3j/abi/datatypes/DynamicArrayTest.java
+++ b/abi/src/test/java/org/web3j/abi/datatypes/DynamicArrayTest.java
@@ -12,7 +12,6 @@
  */
 package org.web3j.abi.datatypes;
 
-import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -52,12 +51,11 @@ public class DynamicArrayTest {
 
     @Test
     public void testMultidimensionalDynamicArray() {
-        List<List<BigInteger>> input = new ArrayList<>();
         DynamicArray<DynamicArray> array = new DynamicArray<>(
                 DynamicArray.class,
-                List.of(new DynamicArray<DynamicArray>(
+                List.of(new DynamicArray<>(
                                 DynamicArray.class,
-                                List.of(new DynamicArray<Uint256>(Uint256.class, new ArrayList<>()))
+                                List.of(new DynamicArray<>(Uint256.class, new ArrayList<>()))
                         )
                 ));
         assertEquals("uint256[][][]", array.getTypeAsString());


### PR DESCRIPTION
### What does this PR do?

Attention!   This is a second version  of https://github.com/LFDT-web3j/web3j/pull/2186  -  there was  rebasing mishap on my side due to sign off comments 

Fixes this bug:

https://github.com/LFDT-web3j/web3j/issues/1912

### Where should the reviewer start?
Where should the reviewer start?
By looking into function signature generation. Actual release produces wrong result for multidimensional arrays.

This function:
```

    function execute(
        uint256 foo,  // start amount or 0
        uint256 bar,  // also start amount or 0
        uint256 baz, // last block we are willing to execute
        address[] calldata glyrge, //  list of pairs
        uint256[][] calldata whatever, //  expected reserves
        bytes calldata _data // all other data for further exchanges
    )  external;
```
Produces this parameter signature while encoding:

`uint256,uint256,uint256,address[],dynamicarray[],bytes    `

Which is plain wrong, and does not match deployed contract.

### Why is it needed?
It would be nice to be able to call contracts methods with multidimensional array parameters:

`uint256[][]`

Higher dimensions also work as demonstrated by test

## Checklist

- [x] I've read the contribution guidelines.
- [x] I've added tests (if applicable).
- [x] I've added a changelog entry if necessary.
