### PR TITLE
Fix ClassNotFoundException on Windows during project generation

### DIFF
--- a/codegen/src/main/java/org/web3j/codegen/unit/gen/CompilerClassLoader.java
+++ b/codegen/src/main/java/org/web3j/codegen/unit/gen/CompilerClassLoader.java
@@ -126,7 +126,7 @@ public class CompilerClassLoader extends ClassLoader {
 
     private String extractClassName(final String pathName) {
         return pathName.substring(outputDir.toString().length() + 1, pathName.lastIndexOf("."))
-                .replaceAll("/", ".");
+                .replaceAll("[/\\\\]", ".");
     }
 
     private String buildClassPath() {


### PR DESCRIPTION
### What does this PR do?
Fix this error in windows when creating new project using the _web3j new_ command:
```
java.lang.IllegalStateException: java.lang.ClassNotFoundException: org.web3j.generated.contracts.ERC20Token
at org.web3j.codegen.unit.gen.ClassProvider.loadClass(ClassProvider.java:63)
```
The extractClassName() method will replace "/" to "." to resolve the fully qualified class name, however, this doesn't work on windows because windows use "\\" instead of "/" in the path, so the class name is not extracted correctly, causing the ClassNotFoundException

### Where should the reviewer start?
codegen/src/main/java/org/web3j/codegen/unit/gen/CompilerClassLoader.java

### Why is it needed?
explained above

## Checklist

- [ ] I've read the contribution guidelines.
- [ ] I've added tests (if applicable).
- [ ] I've added a changelog entry if necessary.