### PR TITLE
Not adding blob sidecar for EIP-4844 transaction when encoding for signing

### DIFF
--- a/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction4844.java
+++ b/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction4844.java
@@ -153,17 +153,20 @@ public class Transaction4844 extends Transaction1559 implements ITransaction {
             resultTx.add(
                     RlpString.create(
                             org.web3j.utils.Bytes.trimLeadingZeroes(signatureData.getS())));
+
+            List<RlpType> result = new ArrayList<>();
+            result.add(new RlpList(resultTx));
+
+            // Adding blobs, commitments, and proofs
+            result.add(new RlpList(getRlpBlobs()));
+            result.add(new RlpList(getRlpKzgCommitments()));
+            result.add(new RlpList(getRlpKzgProofs()));
+
+            return result;
+        } else {
+            // encoding for signature, blob sidecar cannot be added
+            return resultTx;
         }
-
-        List<RlpType> result = new ArrayList<>();
-        result.add(new RlpList(resultTx));
-
-        // Adding blobs, commitments, and proofs
-        result.add(new RlpList(getRlpBlobs()));
-        result.add(new RlpList(getRlpKzgCommitments()));
-        result.add(new RlpList(getRlpKzgProofs()));
-
-        return result;
     }
 
     public static Transaction4844 createTransaction(


### PR DESCRIPTION

### What does this PR do?
Fixes encoding of EIP-4844 transaction for signing

### Where should the reviewer start?
`Transaction4844::asRlpValues`

### Why is it needed?
I've created a PR to the web3signer repository: https://github.com/Consensys/web3signer/pull/1096/files#diff-e3e39c1cb1261aafa22d5bc9fb0e0e28d222a209801620a9242e77c37dfe259eR64
And the serialisation produced wrong signer. When I digged into  web3j I realised that for signing EIP-4844 an additional list is added: `List<RlpType> result = new ArrayList<>();` this list shifts signature bytes which are wrongly interpreted when deserialising. That's why I don't add this sidecar list when creating signature. Let me know if it's correct approach.

## Checklist

- [x] I've read the contribution guidelines.
- [ ] I've added tests (if applicable).
- [ ] I've added a changelog entry if necessary.


issue: https://github.com/LFDT-web3j/web3j/issues/2195