### PR TITLE
Fix missing weiValue in transaction when estimating gas for payable function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * bump snapshot version to 4.14.1 [#2176](https://github.com/hyperledger-web3j/web3j/pull/2176)
 * add encoding/decoding for EIP-7702 transactions [#2178](https://github.com/LFDT-web3j/web3j/pull/2178)
 * add support for Account Abstraction EIP-4337 transactions [#2187](https://github.com/LFDT-web3j/web3j/pull/2187)
+* fix missing weiValue in transaction when estimating gas for payable function
 
 ### BREAKING CHANGES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * bump snapshot version to 4.14.1 [#2176](https://github.com/hyperledger-web3j/web3j/pull/2176)
 * add encoding/decoding for EIP-7702 transactions [#2178](https://github.com/LFDT-web3j/web3j/pull/2178)
 * add support for Account Abstraction EIP-4337 transactions [#2187](https://github.com/LFDT-web3j/web3j/pull/2187)
-* fix missing weiValue in transaction when estimating gas for payable function
+* fix missing weiValue in transaction when estimating gas for payable function [#1268](https://github.com/LFDT-web3j/web3j/issues/1268)
 
 ### BREAKING CHANGES
 

--- a/core/src/main/java/org/web3j/tx/Contract.java
+++ b/core/src/main/java/org/web3j/tx/Contract.java
@@ -401,7 +401,7 @@ public abstract class Contract extends ManagedTransaction {
                                 data,
                                 weiValue,
                                 eip1559GasProvider.getGasLimit(
-                                        getGenericTransaction(data, constructor)),
+                                        getGenericTransaction(data, constructor, weiValue)),
                                 eip1559GasProvider.getMaxPriorityFeePerGas(),
                                 eip1559GasProvider.getMaxFeePerGas(),
                                 constructor);
@@ -414,7 +414,7 @@ public abstract class Contract extends ManagedTransaction {
                                 data,
                                 weiValue,
                                 gasProvider.getGasPrice(),
-                                gasProvider.getGasLimit(getGenericTransaction(data, constructor)),
+                                gasProvider.getGasLimit(getGenericTransaction(data, constructor, weiValue)),
                                 constructor);
             }
         } catch (JsonRpcError error) {
@@ -449,12 +449,14 @@ public abstract class Contract extends ManagedTransaction {
         return receipt;
     }
 
-    protected Transaction getGenericTransaction(String data, boolean constructor) {
+    protected Transaction getGenericTransaction(String data, boolean constructor, BigInteger weiValue) {
         if (constructor) {
             return Transaction.createContractTransaction(
                     this.transactionManager.getFromAddress(),
                     BigInteger.ONE,
                     gasProvider.getGasPrice(),
+                    gasProvider.getGasLimit(),
+                    weiValue,
                     data);
         } else {
             return Transaction.createFunctionCallTransaction(
@@ -463,6 +465,7 @@ public abstract class Contract extends ManagedTransaction {
                     gasProvider.getGasPrice(),
                     gasProvider.getGasLimit(),
                     contractAddress,
+                    weiValue,
                     data);
         }
     }


### PR DESCRIPTION
### What does this PR do?
to fix #1268 

Fix an issue where the **weiValue** is not set in the constructed transaction during gas estimation for a payable function, which leads to failure.

### Where should the reviewer start?
org.web3j.tx.Contract

### Why is it needed?
When estimating gas for a payable function, the transaction must include the correct **weiValue** to reflect the actual call conditions. Without setting the **weiValue**, the gas estimation does not accurately represent a real invocation, and in many contracts, this leads to a revert or failure during the estimation phase.

This fix ensures the **weiValue** is properly included in the transaction used for gas estimation, which allows the estimation to succeed and reflect real execution costs.

## Checklist

- [x] I've read the contribution guidelines.
- [x] I've added tests (if applicable).
- [x] I've added a changelog entry if necessary.