### PR TITLE
fix: codegen for struct array params defined in interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-*
+* Fix codegen for struct array parameters defined in interfaces [#1995](https://github.com/LFDT-web3j/web3j/issues/1995)
 
 ### Features
 

--- a/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
+++ b/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
@@ -1312,7 +1312,7 @@ public class SolidityFunctionWrapper extends Generator {
         if (namedType.getType().equals("tuple")) {
             typeName = structClassNameMap.get(namedType.structIdentifier());
         } else if (namedType.getType().startsWith("tuple") && namedType.getType().contains("[")) {
-            typeName = buildStructArrayTypeName(namedType, true);
+            typeName = buildStructArrayTypeName(namedType, useNativeJavaTypes);
         } else {
             typeName = getWrapperType(buildParameterType(namedType, useJavaPrimitiveTypes).type);
         }

--- a/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperGeneratorTest.java
+++ b/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperGeneratorTest.java
@@ -256,6 +256,13 @@ public class SolidityFunctionWrapperGeneratorTest extends TempFileProvider {
     }
 
     @Test
+    public void testInterfaceStructArrayGeneration() throws Exception {
+        testCodeGeneration("interfacestructarray", "InterfaceStructArray", JAVA_TYPES_ARG, false);
+        testCodeGeneration(
+                "interfacestructarray", "InterfaceStructArray", SOLIDITY_TYPES_ARG, false);
+    }
+
+    @Test
     public void testStaticArrayOfStructsInStructGeneration() throws Exception {
         testCodeGeneration(
                 "staticarrayofstructsinstruct",

--- a/codegen/src/test/resources/solidity/interfacestructarray/InterfaceStructArray.sol
+++ b/codegen/src/test/resources/solidity/interfacestructarray/InterfaceStructArray.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+
+interface IERC721CollectionV2 {
+
+    struct ItemParam {
+        string rarity;
+        uint256 price;
+        address beneficiary;
+        string metadata;
+    }
+
+    function initialize(
+        string memory _name,
+        string memory _symbol,
+        string memory _baseURI,
+        address _creator,
+        bool _shouldComplete,
+        bool _isApproved,
+        address _rarities,
+        ItemParam[] memory _items
+    ) external;
+}

--- a/codegen/src/test/resources/solidity/interfacestructarray/build/InterfaceStructArray.abi
+++ b/codegen/src/test/resources/solidity/interfacestructarray/build/InterfaceStructArray.abi
@@ -1,0 +1,28 @@
+[
+  {
+    "inputs": [
+      {"internalType": "string",  "name": "_name",           "type": "string"},
+      {"internalType": "string",  "name": "_symbol",         "type": "string"},
+      {"internalType": "string",  "name": "_baseURI",        "type": "string"},
+      {"internalType": "address", "name": "_creator",        "type": "address"},
+      {"internalType": "bool",    "name": "_shouldComplete",  "type": "bool"},
+      {"internalType": "bool",    "name": "_isApproved",     "type": "bool"},
+      {"internalType": "address", "name": "_rarities",       "type": "address"},
+      {
+        "components": [
+          {"internalType": "string",  "name": "rarity",      "type": "string"},
+          {"internalType": "uint256", "name": "price",       "type": "uint256"},
+          {"internalType": "address", "name": "beneficiary", "type": "address"},
+          {"internalType": "string",  "name": "metadata",    "type": "string"}
+        ],
+        "internalType": "struct IERC721CollectionV2.ItemParam[]",
+        "name": "_items",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]


### PR DESCRIPTION
### What does this PR do?
Fixes a bug where generating a Java wrapper for a Solidity interface containing a struct array parameter produced uncompilable code when using solidity types mode.

### Where should the reviewer start?
`SolidityFunctionWrapper.java` in the `getTypenameForArray` method (line 1315). Single-line fix changes hardcoded `true` to `useNativeJavaTypes` when calling `buildStructArrayTypeName` for struct array parameters.

### Why is it needed?
When `useNativeJavaTypes=false`, the struct array parameter got `List<StructName>` in the method signature while all other params correctly got web3j types (`Utf8String`, `Address`, `Bool`). The generated body then passed the bare `List<StructName>` to `Arrays.<Type>asList()`, causing a compile error since `List<StructName>` is not a `Type`. 
Fixes #1995

## Checklist                                                                                                                                                                                                  
                  
- [x] I've read the contribution guidelines.
- [x] I've added tests (if applicable).
- [x] I've added a changelog entry if necessary.                                                                                                                                                              