### PR TITLE
Fix incorrect EIP-4844 transaction encoding for signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Fix Utf8String encoding + dynamic array for non-ASCII characters [#2289](https://github.com/LFDT-web3j/web3j/pull/2289)
 - Fix Transaction serialization failure when fee fields are null [#2293](https://github.com/LFDT-web3j/web3j/pull/2293)
 - Fix NullPointerException when deriving child keys from public-only Bip32ECKeyPair [#2284](https://github.com/LFDT-web3j/web3j/pull/2284)
+- Fix incorrect EIP-4844 transaction encoding for signing [#2257](https://github.com/LFDT-web3j/web3j/pull/2257)
 
 
 ### Features

--- a/crypto/src/main/java/org/web3j/crypto/TransactionEncoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/TransactionEncoder.java
@@ -38,8 +38,7 @@ public class TransactionEncoder {
      * @return signature
      */
     public static byte[] signMessage(RawTransaction rawTransaction, Credentials credentials) {
-        Sign.SignatureData signatureData =
-                signMessageToSignatureData(rawTransaction, credentials);
+        Sign.SignatureData signatureData = signMessageToSignatureData(rawTransaction, credentials);
 
         return encodeNetwork(rawTransaction, signatureData);
     }

--- a/crypto/src/main/java/org/web3j/crypto/TransactionEncoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/TransactionEncoder.java
@@ -38,37 +38,44 @@ public class TransactionEncoder {
      * @return signature
      */
     public static byte[] signMessage(RawTransaction rawTransaction, Credentials credentials) {
+        Sign.SignatureData signatureData =
+                signMessageToSignatureData(rawTransaction, credentials);
+
+        return encodeNetwork(rawTransaction, signatureData);
+    }
+
+    public static Sign.SignatureData signMessageToSignatureData(
+            RawTransaction rawTransaction, Credentials credentials) {
         byte[] encodedTransaction;
         if (rawTransaction.getTransaction().getType().isEip4844()) {
             encodedTransaction = encode4844(rawTransaction);
         } else {
             encodedTransaction = encode(rawTransaction);
         }
-        Sign.SignatureData signatureData =
-                Sign.signMessage(encodedTransaction, credentials.getEcKeyPair());
-
-        return encode(rawTransaction, signatureData);
+        return Sign.signMessage(encodedTransaction, credentials.getEcKeyPair());
     }
 
-    /**
-     * Use for legacy txs (after Eip155 before Eip1559)
-     *
-     * @return signature
-     */
-    public static byte[] signMessage(
+    public static Sign.SignatureData signMessageToSignatureData(
             RawTransaction rawTransaction, long chainId, Credentials credentials) {
-
-        // Eip1559: Tx has ChainId inside
-        if (rawTransaction.getType().isEip1559()) {
-            return signMessage(rawTransaction, credentials);
+        if (rawTransaction.getType().isEip1559()
+                || rawTransaction.getType().isEip2930()
+                || rawTransaction.getType().isEip4844()
+                || rawTransaction.getType().isEip7702()) {
+            return signMessageToSignatureData(rawTransaction, credentials);
         }
 
         byte[] encodedTransaction = encode(rawTransaction, chainId);
         Sign.SignatureData signatureData =
                 Sign.signMessage(encodedTransaction, credentials.getEcKeyPair());
 
-        Sign.SignatureData eip155SignatureData = createEip155SignatureData(signatureData, chainId);
-        return encode(rawTransaction, eip155SignatureData);
+        return createEip155SignatureData(signatureData, chainId);
+    }
+
+    public static byte[] signMessage(
+            RawTransaction rawTransaction, long chainId, Credentials credentials) {
+        Sign.SignatureData signatureData =
+                signMessageToSignatureData(rawTransaction, chainId, credentials);
+        return encode(rawTransaction, signatureData);
     }
 
     @Deprecated
@@ -132,6 +139,22 @@ public class TransactionEncoder {
                     .array();
         }
         return encoded;
+    }
+
+    public static byte[] encodeNetwork(
+            RawTransaction rawTransaction, Sign.SignatureData signatureData) {
+        if (!rawTransaction.getType().isEip4844()) {
+            return encode(rawTransaction, signatureData);
+        }
+
+        List<RlpType> values = rawTransaction.getTransaction().asNetworkRlpValues(signatureData);
+        RlpList rlpList = new RlpList(values);
+        byte[] encoded = RlpEncoder.encode(rlpList);
+
+        return ByteBuffer.allocate(encoded.length + 1)
+                .put(rawTransaction.getType().getRlpType())
+                .put(encoded)
+                .array();
     }
 
     public static byte[] encode4844(RawTransaction rawTransaction) {

--- a/crypto/src/main/java/org/web3j/crypto/TransactionUtils.java
+++ b/crypto/src/main/java/org/web3j/crypto/TransactionUtils.java
@@ -19,17 +19,11 @@ public class TransactionUtils {
     private static final int CHAIN_ID_INC = 35;
     private static final int LOWER_REAL_V = 27;
 
-    /**
-     * Utility method to provide the transaction hash for a given transaction.
-     *
-     * @param rawTransaction we wish to send
-     * @param credentials of the sender
-     * @return encoded transaction hash
-     */
     public static byte[] generateTransactionHash(
             RawTransaction rawTransaction, Credentials credentials) {
-        byte[] signedMessage = TransactionEncoder.signMessage(rawTransaction, credentials);
-        return Hash.sha3(signedMessage);
+        Sign.SignatureData signatureData =
+                TransactionEncoder.signMessageToSignatureData(rawTransaction, credentials);
+        return Hash.sha3(TransactionEncoder.encode(rawTransaction, signatureData));
     }
 
     /**
@@ -42,9 +36,12 @@ public class TransactionUtils {
      */
     public static byte[] generateTransactionHash(
             RawTransaction rawTransaction, byte chainId, Credentials credentials) {
-        byte[] signedMessage = TransactionEncoder.signMessage(rawTransaction, chainId, credentials);
-        return Hash.sha3(signedMessage);
+        Sign.SignatureData signatureData =
+                TransactionEncoder.signMessageToSignatureData(
+                        rawTransaction, (long) chainId, credentials);
+        return Hash.sha3(TransactionEncoder.encode(rawTransaction, signatureData));
     }
+
 
     /**
      * Utility method to provide the transaction hash for a given transaction.

--- a/crypto/src/main/java/org/web3j/crypto/TransactionUtils.java
+++ b/crypto/src/main/java/org/web3j/crypto/TransactionUtils.java
@@ -42,7 +42,6 @@ public class TransactionUtils {
         return Hash.sha3(TransactionEncoder.encode(rawTransaction, signatureData));
     }
 
-
     /**
      * Utility method to provide the transaction hash for a given transaction.
      *

--- a/crypto/src/main/java/org/web3j/crypto/transaction/type/ITransaction.java
+++ b/crypto/src/main/java/org/web3j/crypto/transaction/type/ITransaction.java
@@ -26,7 +26,6 @@ public interface ITransaction {
         return asRlpValues(signatureData);
     }
 
-
     BigInteger getNonce();
 
     BigInteger getGasPrice();

--- a/crypto/src/main/java/org/web3j/crypto/transaction/type/ITransaction.java
+++ b/crypto/src/main/java/org/web3j/crypto/transaction/type/ITransaction.java
@@ -22,6 +22,11 @@ public interface ITransaction {
 
     List<RlpType> asRlpValues(Sign.SignatureData signatureData);
 
+    default List<RlpType> asNetworkRlpValues(Sign.SignatureData signatureData) {
+        return asRlpValues(signatureData);
+    }
+
+
     BigInteger getNonce();
 
     BigInteger getGasPrice();

--- a/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction4844.java
+++ b/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction4844.java
@@ -482,7 +482,6 @@ public class Transaction4844 extends Transaction1559 implements ITransaction {
         return asRlpValues(signatureData);
     }
 
-
     /**
      * Builds tx_payload_body: the 11 unsigned fields (+ optional v/r/s when signing). This is also
      * the hash-signing input when signatureData is null.

--- a/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction4844.java
+++ b/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction4844.java
@@ -466,23 +466,22 @@ public class Transaction4844 extends Transaction1559 implements ITransaction {
     //       (which internally delegates to asNetworkRlpValues when sidecar present)
     // =========================================================================
 
-    /**
-     * Returns the RLP field list for the transaction payload body only (tx_payload_body). When
-     * signatureData is not null, includes v/r/s and then delegates to {@link
-     * #buildNetworkWrapper(Sign.SignatureData)} to append the blob sidecar.
-     */
     @Override
     public List<RlpType> asRlpValues(Sign.SignatureData signatureData) {
-        List<RlpType> txPayloadBody = buildTxPayloadBody(signatureData);
+        return buildTxPayloadBody(signatureData);
+    }
 
-        if (signatureData != null && hasAnySidecar()) {
-            // Produce the full network wrapper as a flat list so TransactionEncoder
-            // wraps it in a single RlpList → 0x03 || rlp([...])
+    @Override
+    public List<RlpType> asNetworkRlpValues(Sign.SignatureData signatureData) {
+        if (signatureData == null) {
+            return asRlpValues(null);
+        }
+        if (hasAnySidecar()) {
             return buildNetworkWrapper(signatureData);
         }
-
-        return txPayloadBody;
+        return asRlpValues(signatureData);
     }
+
 
     /**
      * Builds tx_payload_body: the 11 unsigned fields (+ optional v/r/s when signing). This is also

--- a/crypto/src/test/java/org/web3j/crypto/TransactionDecoderTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/TransactionDecoderTest.java
@@ -382,7 +382,7 @@ public class TransactionDecoderTest {
 
         final Sign.SignatureData fakeSignatureData =
                 new Sign.SignatureData(new byte[] {27}, new byte[] {0}, new byte[] {0});
-        final byte[] encodedMessage = TransactionEncoder.encode(rawTransaction, fakeSignatureData);
+        final byte[] encodedMessage = TransactionEncoder.encodeNetwork(rawTransaction, fakeSignatureData);
         final String hexMessage = Numeric.toHexString(encodedMessage);
 
         final RawTransaction result = TransactionDecoder.decode(hexMessage);

--- a/crypto/src/test/java/org/web3j/crypto/TransactionDecoderTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/TransactionDecoderTest.java
@@ -382,7 +382,8 @@ public class TransactionDecoderTest {
 
         final Sign.SignatureData fakeSignatureData =
                 new Sign.SignatureData(new byte[] {27}, new byte[] {0}, new byte[] {0});
-        final byte[] encodedMessage = TransactionEncoder.encodeNetwork(rawTransaction, fakeSignatureData);
+        final byte[] encodedMessage =
+                TransactionEncoder.encodeNetwork(rawTransaction, fakeSignatureData);
         final String hexMessage = Numeric.toHexString(encodedMessage);
 
         final RawTransaction result = TransactionDecoder.decode(hexMessage);


### PR DESCRIPTION
This PR fixes an issue with EIP-4844 transaction signing where the RLP encoding used for signing incorrectly included blob sidecar data (blobs, commitments and proofs).

According to the EIP-4844 specification, the signature should be calculated only over the transaction payload body. Including the blob sidecar data changes the RLP structure and results in an incorrect signature and wrong recovered signer address.

This change separates the RLP encoding used for signing from the encoding used for network transmission, ensuring that signing uses only the correct transaction payload body, while the full structure is still used for network encoding.

This also fixes transaction hash calculation for EIP-4844 transactions to ensure it is calculated from:
0x03 || rlp(TransactionPayloadBody)

Tests were updated and existing crypto module tests pass.

Fixes #2195
