### PR TITLE
fix(integration-tests): dynamically remove unstable legacy sonatype repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Fix pass accessList to parent in Transaction7702 constructor [#2292](https://github.com/LFDT-web3j/web3j/pull/2292)
 - Fix Transaction serialization failure when fee fields are null [#2293](https://github.com/LFDT-web3j/web3j/pull/2293)
 - Fix stale EIP-7691 blob base-fee update fraction [#2300](https://github.com/LFDT-web3j/web3j/pull/2300)
+- Fix integration-tests: dynamically remove unstable legacy Sonatype repositories [#2304](https://github.com/LFDT-web3j/web3j/pull/2304)
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Fix pass accessList to parent in Transaction7702 constructor [#2292](https://github.com/LFDT-web3j/web3j/pull/2292)
 - Fix Transaction serialization failure when fee fields are null [#2293](https://github.com/LFDT-web3j/web3j/pull/2293)
 - Fix stale EIP-7691 blob base-fee update fraction [#2300](https://github.com/LFDT-web3j/web3j/pull/2300)
-- Fix integration-tests: dynamically remove unstable legacy Sonatype repositories [#2304](https://github.com/LFDT-web3j/web3j/pull/2304)
+- Fix integration-tests: remove unstable legacy Sonatype repositories [#2304](https://github.com/LFDT-web3j/web3j/pull/2304)
 
 ### Features
 

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -2,8 +2,9 @@ description 'web3j integration tests'
 
 
 repositories {
-    maven { url 'https://oss.sonatype.org/content/repositories/releases/' }
-    maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
+    repositories.removeIf { repo ->
+        repo instanceof MavenArtifactRepository && repo.url.toString().contains('oss.sonatype.org')
+    }
     maven { url "https://hyperledger.jfrog.io/artifactory/besu-maven/" }
     maven { url "https://artifacts.consensys.net/public/maven/maven/" }
     maven { url "https://splunk.jfrog.io/splunk/ext-releases-local" }

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -2,9 +2,6 @@ description 'web3j integration tests'
 
 
 repositories {
-    repositories.removeIf { repo ->
-        repo instanceof MavenArtifactRepository && repo.url.toString().contains('oss.sonatype.org')
-    }
     maven { url "https://hyperledger.jfrog.io/artifactory/besu-maven/" }
     maven { url "https://artifacts.consensys.net/public/maven/maven/" }
     maven { url "https://splunk.jfrog.io/splunk/ext-releases-local" }


### PR DESCRIPTION
The `integration-test` job has been failing on CI with gateway timeouts (504) while trying to download dependencies from `oss.sonatype.org`. Since Sonatype's legacy staging repository is unstable, Gradle gets blocked on the timeout and aborts before checking subsequent working repositories that actually contain the required artifacts.

This PR adds a dynamic `removeIf` filter in the subproject's repositories container to strip any legacy `oss.sonatype.org` repository. We do this dynamically because the parent build tools configuration applies these repositories to all subprojects via `allprojects`, so simply removing them from the local file alone doesn't clear them.

Tested locally by compiling the project and running the integration tests with `--refresh-dependencies` to ensure clean resolution.
