### PR TITLE
feat: add CappedDynamicEIP1559GasProvider with max fee cap functionality

### DIFF
--- a/.agents/skills/web3j/assets/erc20-example/basic-erc20-app/src/main/java/example/Erc20ExampleApp.java
+++ b/.agents/skills/web3j/assets/erc20-example/basic-erc20-app/src/main/java/example/Erc20ExampleApp.java
@@ -1,11 +1,25 @@
+/*
+ * Copyright 2026 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package example;
 
-import example.contracts.ExampleToken;
-import io.reactivex.disposables.Disposable;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+
+import example.contracts.ExampleToken;
+import io.reactivex.disposables.Disposable;
+
 import org.web3j.crypto.Credentials;
 import org.web3j.protocol.Web3j;
 import org.web3j.protocol.core.DefaultBlockParameterName;
@@ -46,7 +60,8 @@ public final class Erc20ExampleApp {
             System.out.println("Token name: " + token.name().send());
             System.out.println("Token symbol: " + token.symbol().send());
             System.out.println("Total supply: " + token.totalSupply().send());
-            System.out.println("Deployer balance: " + token.balanceOf(credentials.getAddress()).send());
+            System.out.println(
+                    "Deployer balance: " + token.balanceOf(credentials.getAddress()).send());
 
             CountDownLatch eventSeen = new CountDownLatch(1);
             transferSubscription =
@@ -69,7 +84,8 @@ public final class Erc20ExampleApp {
             TransactionReceipt receipt = token.transfer(recipient, transferAmount).send();
             System.out.println("Transfer tx hash: " + receipt.getTransactionHash());
 
-            List<ExampleToken.TransferEventResponse> receiptEvents = token.getTransferEvents(receipt);
+            List<ExampleToken.TransferEventResponse> receiptEvents =
+                    token.getTransferEvents(receipt);
             if (!receiptEvents.isEmpty()) {
                 ExampleToken.TransferEventResponse event = receiptEvents.get(0);
                 System.out.printf(

--- a/.agents/skills/web3j/assets/erc20-example/basic-erc20-app/src/test/java/example/Erc20EvmTest.java
+++ b/.agents/skills/web3j/assets/erc20-example/basic-erc20-app/src/test/java/example/Erc20EvmTest.java
@@ -1,11 +1,25 @@
+/*
+ * Copyright 2026 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package example;
 
-import example.contracts.ExampleToken;
-import io.reactivex.disposables.Disposable;
 import java.math.BigInteger;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+
+import example.contracts.ExampleToken;
+import io.reactivex.disposables.Disposable;
 import org.junit.jupiter.api.Test;
+
 import org.web3j.EVMTest;
 import org.web3j.NodeType;
 import org.web3j.protocol.Web3j;
@@ -22,9 +36,7 @@ class Erc20EvmTest {
 
     @Test
     void deploysTransfersAndStreamsEvents(
-            Web3j web3j,
-            TransactionManager transactionManager,
-            ContractGasProvider gasProvider)
+            Web3j web3j, TransactionManager transactionManager, ContractGasProvider gasProvider)
             throws Exception {
         ExampleToken token =
                 ExampleToken.deploy(
@@ -52,7 +64,8 @@ class Erc20EvmTest {
             String recipient = "0x00000000000000000000000000000000000000b0";
             TransactionReceipt receipt = token.transfer(recipient, BigInteger.valueOf(25L)).send();
 
-            ExampleToken.TransferEventResponse transferEvent = token.getTransferEvents(receipt).get(0);
+            ExampleToken.TransferEventResponse transferEvent =
+                    token.getTransferEvents(receipt).get(0);
             assertEquals(recipient.toLowerCase(), transferEvent._to.toLowerCase());
             assertEquals(BigInteger.valueOf(25L), transferEvent._value);
             assertEquals(BigInteger.valueOf(25L), token.balanceOf(recipient).send());

--- a/.agents/skills/web3j/assets/event-subscriptions/contract-logs/src/main/java/example/ContractLogSubscriber.java
+++ b/.agents/skills/web3j/assets/event-subscriptions/contract-logs/src/main/java/example/ContractLogSubscriber.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2026 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package example;
 
 import java.util.List;
@@ -30,21 +42,22 @@ public class ContractLogSubscriber {
 
         CountDownLatch keepAlive = new CountDownLatch(1);
         Disposable subscription =
-                web3j.ethLogFlowable(filter).subscribe(
-                        log -> {
-                            List<String> topics = log.getTopics();
-                            System.out.printf(
-                                    "log block=%s tx=%s address=%s topics=%s data=%s%n",
-                                    log.getBlockNumber(),
-                                    log.getTransactionHash(),
-                                    log.getAddress(),
-                                    topics,
-                                    log.getData());
-                        },
-                        error -> {
-                            error.printStackTrace();
-                            keepAlive.countDown();
-                        });
+                web3j.ethLogFlowable(filter)
+                        .subscribe(
+                                log -> {
+                                    List<String> topics = log.getTopics();
+                                    System.out.printf(
+                                            "log block=%s tx=%s address=%s topics=%s data=%s%n",
+                                            log.getBlockNumber(),
+                                            log.getTransactionHash(),
+                                            log.getAddress(),
+                                            topics,
+                                            log.getData());
+                                },
+                                error -> {
+                                    error.printStackTrace();
+                                    keepAlive.countDown();
+                                });
 
         Runtime.getRuntime()
                 .addShutdownHook(
@@ -73,8 +86,7 @@ public class ContractLogSubscriber {
     private static String requireEnv(String name) {
         String value = System.getenv(name);
         if (value == null || value.isBlank()) {
-            throw new IllegalArgumentException(
-                    "Missing required environment variable: " + name);
+            throw new IllegalArgumentException("Missing required environment variable: " + name);
         }
         return value;
     }

--- a/.agents/skills/web3j/assets/event-subscriptions/websocket-newheads/src/main/java/example/NewHeadsSubscriber.java
+++ b/.agents/skills/web3j/assets/event-subscriptions/websocket-newheads/src/main/java/example/NewHeadsSubscriber.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2026 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package example;
 
 import java.net.ConnectException;
@@ -20,12 +32,13 @@ public class NewHeadsSubscriber {
 
         CountDownLatch keepAlive = new CountDownLatch(1);
         Disposable subscription =
-                web3j.newHeadsNotifications().subscribe(
-                        notification -> printHead(notification.getParams().getResult()),
-                        error -> {
-                            error.printStackTrace();
-                            keepAlive.countDown();
-                        });
+                web3j.newHeadsNotifications()
+                        .subscribe(
+                                notification -> printHead(notification.getParams().getResult()),
+                                error -> {
+                                    error.printStackTrace();
+                                    keepAlive.countDown();
+                                });
 
         Runtime.getRuntime()
                 .addShutdownHook(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - Bump snapshot version to 6.0.0 [#2302](https://github.com/LFDT-web3j/web3j/pull/2302)
 - Add support for txpool_contentFrom JSON-RPC method to query transaction pool by address [#2262](https://github.com/LFDT-web3j/web3j/pull/2262)
 - Add support for txpool_inspect JSON-RPC method [#2262](https://github.com/LFDT-web3j/web3j/pull/2262)
+- Add `CappedDynamicEIP1559GasProvider` to enforce an upper bound on EIP-1559 gas fees [#2306](https://github.com/LFDT-web3j/web3j/pull/2306)
 
 ### BREAKING CHANGES
 

--- a/abi/src/main/java/org/web3j/abi/TypeDecoder.java
+++ b/abi/src/main/java/org/web3j/abi/TypeDecoder.java
@@ -764,7 +764,13 @@ public class TypeDecoder {
 
         final T value;
         if (DynamicStruct.class.isAssignableFrom(declaredField)) {
-            value = (T) decodeDynamicStruct(dynamicElementData, 0, (TypeReference) new TypeReference(genericParameterType, false) {});
+            value =
+                    (T)
+                            decodeDynamicStruct(
+                                    dynamicElementData,
+                                    0,
+                                    (TypeReference)
+                                            new TypeReference(genericParameterType, false) {});
         } else if (DynamicArray.class.isAssignableFrom(declaredField)) {
             TypeReference<?> typeRef;
             if (genericParameterType instanceof ParameterizedType) {

--- a/abi/src/test/java/org/web3j/abi/TypeEncoderTest.java
+++ b/abi/src/test/java/org/web3j/abi/TypeEncoderTest.java
@@ -1223,7 +1223,10 @@ public class TypeEncoderTest {
     public void testDynamicUtf8StringsArray() {
         // Test for issue #1741: non-ASCII characters (Chinese, Korean, etc.) encoding
         DynamicArray<Utf8String> array =
-                new DynamicArray<>(Utf8String.class, new Utf8String("\u4f60\u597d"), new Utf8String("\u4e16\u754c"));
+                new DynamicArray<>(
+                        Utf8String.class,
+                        new Utf8String("\u4f60\u597d"),
+                        new Utf8String("\u4e16\u754c"));
 
         // "\u4f60\u597d" UTF-8 = E4BDA0E5A5BD (6 bytes)
         // "\u4e16\u754c" UTF-8 = E4B896E7958C (6 bytes)

--- a/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
+++ b/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
@@ -728,11 +728,13 @@ public class SolidityFunctionWrapper extends Generator {
                 }
 
                 if (nativeTypeName instanceof ParameterizedTypeName) {
-                    ParameterizedTypeName parameterizedTypeName = (ParameterizedTypeName) nativeTypeName;
+                    ParameterizedTypeName parameterizedTypeName =
+                            (ParameterizedTypeName) nativeTypeName;
                     if (parameterizedTypeName.rawType.equals(ClassName.get(DynamicArray.class))) {
                         TypeName elementType = parameterizedTypeName.typeArguments.get(0);
                         while (elementType instanceof ParameterizedTypeName) {
-                            elementType = ((ParameterizedTypeName) elementType).typeArguments.get(0);
+                            elementType =
+                                    ((ParameterizedTypeName) elementType).typeArguments.get(0);
                         }
                         annotationSpec =
                                 AnnotationSpec.builder(Parameterized.class)
@@ -1963,7 +1965,10 @@ public class SolidityFunctionWrapper extends Generator {
                 indexedParameters) {
             final TypeName typeName;
             if (isHashedIndexedType(namedType.getType())) {
-                typeName = useNativeJavaTypes ? TypeName.get(byte[].class) : ClassName.get("org.web3j.abi.datatypes.generated", "Bytes32");
+                typeName =
+                        useNativeJavaTypes
+                                ? TypeName.get(byte[].class)
+                                : ClassName.get("org.web3j.abi.datatypes.generated", "Bytes32");
             } else if (namedType.getType().equals("tuple")) {
                 typeName = structClassNameMap.get(namedType.structIdentifier());
             } else if (namedType.getType().startsWith("tuple")
@@ -2197,9 +2202,8 @@ public class SolidityFunctionWrapper extends Generator {
                 if (isHashedIndexedType(namedTypeName.getType())) {
                     nativeConversion = ".getValue()";
                 } else if (structClassNameMap.values().stream()
-                            .map(ClassName::simpleName)
-                            .noneMatch(
-                                    name -> name.equals(namedTypeName.getTypeName().toString()))) {
+                        .map(ClassName::simpleName)
+                        .noneMatch(name -> name.equals(namedTypeName.getTypeName().toString()))) {
                     nativeConversion = ".getValue()";
                 } else {
                     nativeConversion = "";
@@ -2209,7 +2213,10 @@ public class SolidityFunctionWrapper extends Generator {
             }
             final TypeName indexedEventWrapperType;
             if (isHashedIndexedType(namedTypeName.getType())) {
-                indexedEventWrapperType = useNativeJavaTypes ? TypeName.get(byte[].class) : ClassName.get("org.web3j.abi.datatypes.generated", "Bytes32");
+                indexedEventWrapperType =
+                        useNativeJavaTypes
+                                ? TypeName.get(byte[].class)
+                                : ClassName.get("org.web3j.abi.datatypes.generated", "Bytes32");
             } else if (namedTypeName.getType().equals("tuple")) {
                 indexedEventWrapperType = structClassNameMap.get(namedTypeName.structIdentifier());
             } else if (namedTypeName.getType().startsWith("tuple")

--- a/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
+++ b/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
@@ -1357,17 +1357,29 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
 
     @Test
     public void testBuildEventWithIndexedStruct() throws Exception {
-        java.lang.reflect.Field mapField = SolidityFunctionWrapper.class.getDeclaredField("structClassNameMap");
+        java.lang.reflect.Field mapField =
+                SolidityFunctionWrapper.class.getDeclaredField("structClassNameMap");
         mapField.setAccessible(true);
-        java.util.Map<String, ClassName> map = 
+        java.util.Map<String, ClassName> map =
                 (java.util.Map<String, ClassName>) mapField.get(solidityFunctionWrapper);
         map.put("struct MyContract.SomeStruct", ClassName.get("", "SomeStruct"));
 
-        NamedType struct = new NamedType("myStruct", "tuple", new ArrayList<>(), "struct MyContract.SomeStruct", true);
+        NamedType struct =
+                new NamedType(
+                        "myStruct",
+                        "tuple",
+                        new ArrayList<>(),
+                        "struct MyContract.SomeStruct",
+                        true);
 
         AbiDefinition functionDefinition =
                 new AbiDefinition(
-                        false, Arrays.asList(struct), "Transfer", new ArrayList<>(), "event", false);
+                        false,
+                        Arrays.asList(struct),
+                        "Transfer",
+                        new ArrayList<>(),
+                        "event",
+                        false);
         TypeSpec.Builder builder = TypeSpec.classBuilder("TestClass");
 
         builder.addMethods(
@@ -1386,6 +1398,7 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
         if (url == null) {
             throw new java.io.FileNotFoundException("Resource not found: /expected/" + filename);
         }
-        return new String(java.nio.file.Files.readAllBytes(java.nio.file.Paths.get(url.toURI()))).replace("\r\n", "\n");
+        return new String(java.nio.file.Files.readAllBytes(java.nio.file.Paths.get(url.toURI())))
+                .replace("\r\n", "\n");
     }
 }

--- a/codegen/src/test/java/org/web3j/codegen/StructDynamicArrayDecodeTest.java
+++ b/codegen/src/test/java/org/web3j/codegen/StructDynamicArrayDecodeTest.java
@@ -1,9 +1,20 @@
+/*
+ * Copyright 2026 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package org.web3j.codegen;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import javax.lang.model.element.Modifier;
 
 import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.MethodSpec;
@@ -38,7 +49,8 @@ public class StructDynamicArrayDecodeTest {
     @BeforeEach
     public void setUp() {
         generationReporter = mock(GenerationReporter.class);
-        solidityFunctionWrapper = new SolidityFunctionWrapper(true, false, false, 20, generationReporter);
+        solidityFunctionWrapper =
+                new SolidityFunctionWrapper(true, false, false, 20, generationReporter);
     }
 
     @Test
@@ -46,22 +58,30 @@ public class StructDynamicArrayDecodeTest {
     public void testStructGenerationWithArrays() throws Exception {
         AbiDefinition.NamedType addressArray = new AbiDefinition.NamedType("addrArr", "address[]");
         AbiDefinition.NamedType uintArray = new AbiDefinition.NamedType("uintArr", "uint256[]");
-        AbiDefinition.NamedType uintStaticArray = new AbiDefinition.NamedType("uintStatic", "uint256[10]");
-        AbiDefinition.NamedType nestedAddrArray = new AbiDefinition.NamedType("nestedAddr", "address[][]");
+        AbiDefinition.NamedType uintStaticArray =
+                new AbiDefinition.NamedType("uintStatic", "uint256[10]");
+        AbiDefinition.NamedType nestedAddrArray =
+                new AbiDefinition.NamedType("nestedAddr", "address[][]");
         AbiDefinition.NamedType dynamicBytes = new AbiDefinition.NamedType("rawBytes", "bytes");
 
         AbiDefinition.NamedType structType = new AbiDefinition.NamedType("MyStruct", "tuple");
         structType.setInternalType("struct MyContract.MyStruct");
-        structType.setComponents(Arrays.asList(addressArray, uintArray, uintStaticArray, nestedAddrArray, dynamicBytes));
+        structType.setComponents(
+                Arrays.asList(
+                        addressArray, uintArray, uintStaticArray, nestedAddrArray, dynamicBytes));
 
         AbiDefinition function = new AbiDefinition();
         function.setType("function");
         function.setName("getStruct");
         function.setOutputs(Collections.singletonList(structType));
 
-        java.lang.reflect.Method buildStructTypes = SolidityFunctionWrapper.class.getDeclaredMethod("buildStructTypes", List.class);
+        java.lang.reflect.Method buildStructTypes =
+                SolidityFunctionWrapper.class.getDeclaredMethod("buildStructTypes", List.class);
         buildStructTypes.setAccessible(true);
-        List<TypeSpec> structs = (List<TypeSpec>) buildStructTypes.invoke(solidityFunctionWrapper, Collections.singletonList(function));
+        List<TypeSpec> structs =
+                (List<TypeSpec>)
+                        buildStructTypes.invoke(
+                                solidityFunctionWrapper, Collections.singletonList(function));
 
         TypeSpec myStruct = structs.get(0);
 
@@ -79,20 +99,23 @@ public class StructDynamicArrayDecodeTest {
 
     @Test
     public void testDecodingWithParameterizedAnnotation() {
-        String encodedAddressArray = 
-                "0000000000000000000000000000000000000000000000000000000000000020" +
-                "0000000000000000000000000000000000000000000000000000000000000002" +
-                "0000000000000000000000001234567890123456789012345678901234567890" +
-                "0000000000000000000000000987654321098765432109876543210987654321";
-        String encodedStruct = "0000000000000000000000000000000000000000000000000000000000000020" + encodedAddressArray;
+        String encodedAddressArray =
+                "0000000000000000000000000000000000000000000000000000000000000020"
+                        + "0000000000000000000000000000000000000000000000000000000000000002"
+                        + "0000000000000000000000001234567890123456789012345678901234567890"
+                        + "0000000000000000000000000987654321098765432109876543210987654321";
+        String encodedStruct =
+                "0000000000000000000000000000000000000000000000000000000000000020"
+                        + encodedAddressArray;
 
         DefaultFunctionReturnDecoder decoder = new DefaultFunctionReturnDecoder();
         @SuppressWarnings("unchecked")
-        List<TypeReference<Type>> typeReferences = Collections.singletonList(
-                (TypeReference<Type>) (TypeReference) new TypeReference<TestStruct>() {});
+        List<TypeReference<Type>> typeReferences =
+                Collections.singletonList(
+                        (TypeReference<Type>) (TypeReference) new TypeReference<TestStruct>() {});
 
         List<Type> results = decoder.decodeFunctionResult(encodedStruct, typeReferences);
-        
+
         assertNotNull(results);
         TestStruct decoded = (TestStruct) results.get(0);
         assertEquals(2, decoded.addrArr.getValue().size());
@@ -107,22 +130,29 @@ public class StructDynamicArrayDecodeTest {
         // nestedAddr[0] length: 2
         // address1: 0x1234567890123456789012345678901234567890
         // address2: 0x0987654321098765432109876543210987654321
-        String encoded = 
-                "0000000000000000000000000000000000000000000000000000000000000020" + // struct offset to nestedAddr
-                "0000000000000000000000000000000000000000000000000000000000000020" + // nestedAddr length = 1
-                "0000000000000000000000000000000000000000000000000000000000000001" + 
-                "0000000000000000000000000000000000000000000000000000000000000020" + // inner array offset = 32
-                "0000000000000000000000000000000000000000000000000000000000000002" + // inner array length = 2
-                "0000000000000000000000001234567890123456789012345678901234567890" + // address 1
-                "0000000000000000000000000987654321098765432109876543210987654321";  // address 2
+        String encoded =
+                "0000000000000000000000000000000000000000000000000000000000000020"
+                        + // struct offset to nestedAddr
+                        "0000000000000000000000000000000000000000000000000000000000000020"
+                        + // nestedAddr length = 1
+                        "0000000000000000000000000000000000000000000000000000000000000001"
+                        + "0000000000000000000000000000000000000000000000000000000000000020"
+                        + // inner array offset = 32
+                        "0000000000000000000000000000000000000000000000000000000000000002"
+                        + // inner array length = 2
+                        "0000000000000000000000001234567890123456789012345678901234567890"
+                        + // address 1
+                        "0000000000000000000000000987654321098765432109876543210987654321"; // address 2
 
         DefaultFunctionReturnDecoder decoder = new DefaultFunctionReturnDecoder();
         @SuppressWarnings("unchecked")
-        List<TypeReference<Type>> typeReferences = Collections.singletonList(
-                (TypeReference<Type>) (TypeReference) new TypeReference<TestNestedStruct>() {});
+        List<TypeReference<Type>> typeReferences =
+                Collections.singletonList(
+                        (TypeReference<Type>)
+                                (TypeReference) new TypeReference<TestNestedStruct>() {});
 
         List<Type> results = decoder.decodeFunctionResult(encoded, typeReferences);
-        
+
         assertNotNull(results);
         TestNestedStruct decoded = (TestNestedStruct) results.get(0);
         assertEquals(1, decoded.nestedAddr.getValue().size());
@@ -134,44 +164,50 @@ public class StructDynamicArrayDecodeTest {
         Address addr1 = new Address("0x1234567890123456789012345678901234567890");
         Address addr2 = new Address("0x0987654321098765432109876543210987654321");
         DynamicArray<Address> innerArray = new DynamicArray<>(Address.class, addr1, addr2);
-        DynamicArray<DynamicArray<Address>> outerArray = new DynamicArray<>(
-                (Class<DynamicArray<Address>>) (Class) DynamicArray.class,
-                innerArray
-        );
+        DynamicArray<DynamicArray<Address>> outerArray =
+                new DynamicArray<>(
+                        (Class<DynamicArray<Address>>) (Class) DynamicArray.class, innerArray);
 
         TestNestedStruct originalStruct = new TestNestedStruct(outerArray);
 
-        Function function = new Function(
-                "testFunction",
-                Collections.singletonList(originalStruct),
-                Collections.emptyList()
-        );
+        Function function =
+                new Function(
+                        "testFunction",
+                        Collections.singletonList(originalStruct),
+                        Collections.emptyList());
 
         DefaultFunctionEncoder encoder = new DefaultFunctionEncoder();
         String encoded = encoder.encode(function);
-        
+
         // Strip method ID (4 bytes/8 chars) and "0x"
         String encodedParameters = encoded.substring(10);
 
         DefaultFunctionReturnDecoder decoder = new DefaultFunctionReturnDecoder();
         @SuppressWarnings("unchecked")
-        List<TypeReference<Type>> typeReferences = Collections.singletonList(
-                (TypeReference<Type>) (TypeReference) new TypeReference<TestNestedStruct>() {});
+        List<TypeReference<Type>> typeReferences =
+                Collections.singletonList(
+                        (TypeReference<Type>)
+                                (TypeReference) new TypeReference<TestNestedStruct>() {});
 
         List<Type> results = decoder.decodeFunctionResult(encodedParameters, typeReferences);
 
         assertNotNull(results);
         assertEquals(1, results.size());
         TestNestedStruct decodedStruct = (TestNestedStruct) results.get(0);
-        
+
         assertEquals(1, decodedStruct.nestedAddr.getValue().size());
         assertEquals(2, decodedStruct.nestedAddr.getValue().get(0).getValue().size());
-        assertEquals(addr1.getValue(), decodedStruct.nestedAddr.getValue().get(0).getValue().get(0).getValue());
-        assertEquals(addr2.getValue(), decodedStruct.nestedAddr.getValue().get(0).getValue().get(1).getValue());
+        assertEquals(
+                addr1.getValue(),
+                decodedStruct.nestedAddr.getValue().get(0).getValue().get(0).getValue());
+        assertEquals(
+                addr2.getValue(),
+                decodedStruct.nestedAddr.getValue().get(0).getValue().get(1).getValue());
     }
 
     public static class TestStruct extends DynamicStruct {
         public DynamicArray<Address> addrArr;
+
         public TestStruct(@Parameterized(type = Address.class) DynamicArray<Address> addrArr) {
             super(addrArr);
             this.addrArr = addrArr;
@@ -180,44 +216,56 @@ public class StructDynamicArrayDecodeTest {
 
     public static class TestNestedStruct extends DynamicStruct {
         public DynamicArray<DynamicArray<Address>> nestedAddr;
-        public TestNestedStruct(@Parameterized(type = Address.class) DynamicArray<DynamicArray<Address>> nestedAddr) {
+
+        public TestNestedStruct(
+                @Parameterized(type = Address.class)
+                        DynamicArray<DynamicArray<Address>> nestedAddr) {
             super(nestedAddr);
             this.nestedAddr = nestedAddr;
         }
     }
 
-    private void assertHasParameterizedAnnotation(TypeSpec typeSpec, String paramName, Class<?> expectedType) {
-        MethodSpec constructor = typeSpec.methodSpecs.stream()
-                .filter(m -> m.isConstructor() && m.parameters.size() > 0)
-                .findFirst()
-                .get();
+    private void assertHasParameterizedAnnotation(
+            TypeSpec typeSpec, String paramName, Class<?> expectedType) {
+        MethodSpec constructor =
+                typeSpec.methodSpecs.stream()
+                        .filter(m -> m.isConstructor() && m.parameters.size() > 0)
+                        .findFirst()
+                        .get();
 
-        ParameterSpec parameter = constructor.parameters.stream()
-                .filter(p -> p.name.equals(paramName))
-                .findFirst()
-                .get();
+        ParameterSpec parameter =
+                constructor.parameters.stream()
+                        .filter(p -> p.name.equals(paramName))
+                        .findFirst()
+                        .get();
 
-        AnnotationSpec annotation = parameter.annotations.stream()
-                .filter(a -> a.type.toString().equals(Parameterized.class.getName()))
-                .findFirst()
-                .orElseThrow(() -> new AssertionError("Missing @Parameterized on " + paramName));
-        
-        assertTrue(annotation.members.get("type").toString().contains(expectedType.getSimpleName()));
+        AnnotationSpec annotation =
+                parameter.annotations.stream()
+                        .filter(a -> a.type.toString().equals(Parameterized.class.getName()))
+                        .findFirst()
+                        .orElseThrow(
+                                () -> new AssertionError("Missing @Parameterized on " + paramName));
+
+        assertTrue(
+                annotation.members.get("type").toString().contains(expectedType.getSimpleName()));
     }
 
     private void assertNoParameterizedAnnotation(TypeSpec typeSpec, String paramName) {
-        MethodSpec constructor = typeSpec.methodSpecs.stream()
-                .filter(m -> m.isConstructor() && m.parameters.size() > 0)
-                .findFirst()
-                .get();
+        MethodSpec constructor =
+                typeSpec.methodSpecs.stream()
+                        .filter(m -> m.isConstructor() && m.parameters.size() > 0)
+                        .findFirst()
+                        .get();
 
-        ParameterSpec parameter = constructor.parameters.stream()
-                .filter(p -> p.name.equals(paramName))
-                .findFirst()
-                .get();
+        ParameterSpec parameter =
+                constructor.parameters.stream()
+                        .filter(p -> p.name.equals(paramName))
+                        .findFirst()
+                        .get();
 
-        boolean present = parameter.annotations.stream()
-                .anyMatch(a -> a.type.toString().equals(Parameterized.class.getName()));
+        boolean present =
+                parameter.annotations.stream()
+                        .anyMatch(a -> a.type.toString().equals(Parameterized.class.getName()));
         assertFalse(present, paramName + " should NOT have annotation");
     }
 }

--- a/core/src/main/java/org/web3j/protocol/core/methods/request/Transaction.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/request/Transaction.java
@@ -29,7 +29,18 @@ import org.web3j.utils.Numeric;
  * </ol>
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"from", "to", "gas", "gasPrice", "value", "data", "nonce", "chainId", "maxPriorityFeePerGas", "maxFeePerGas"})
+@JsonPropertyOrder({
+    "from",
+    "to",
+    "gas",
+    "gasPrice",
+    "value",
+    "data",
+    "nonce",
+    "chainId",
+    "maxPriorityFeePerGas",
+    "maxFeePerGas"
+})
 public class Transaction {
     // default as per https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_sendtransaction
     public static final BigInteger DEFAULT_GAS = BigInteger.valueOf(9000);

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/TxPoolContentFrom.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/TxPoolContentFrom.java
@@ -32,8 +32,7 @@ public final class TxPoolContentFrom extends Response<TxPoolContentFrom.TxPoolCo
         public TxPoolContentFromResult() {}
 
         public TxPoolContentFromResult(
-                Map<BigInteger, Transaction> pending,
-                Map<BigInteger, Transaction> queued) {
+                Map<BigInteger, Transaction> pending, Map<BigInteger, Transaction> queued) {
             this.pending = immutableCopy(pending, Function.identity());
             this.queued = immutableCopy(queued, Function.identity());
         }

--- a/core/src/main/java/org/web3j/protocol/http/HttpService.java
+++ b/core/src/main/java/org/web3j/protocol/http/HttpService.java
@@ -170,8 +170,7 @@ public class HttpService extends Service {
                 String text = responseBody == null ? "N/A" : responseBody.string();
 
                 throw new ClientConnectionException(
-                        code,
-                        "Invalid response received: " + code + "; " + text);
+                        code, "Invalid response received: " + code + "; " + text);
             }
         }
     }

--- a/core/src/main/java/org/web3j/service/HSMHTTPRequestProcessor.java
+++ b/core/src/main/java/org/web3j/service/HSMHTTPRequestProcessor.java
@@ -67,8 +67,7 @@ public abstract class HSMHTTPRequestProcessor<T extends HSMHTTPPass>
                 int code = response.code();
                 String text = responseBody == null ? "N/A" : responseBody.string();
                 throw new ClientConnectionException(
-                        code,
-                        "Invalid response received: " + code + "; " + text);
+                        code, "Invalid response received: " + code + "; " + text);
             }
         } catch (IOException e) {
             log.error(e.getMessage(), e);

--- a/core/src/main/java/org/web3j/tx/gas/CappedDynamicEIP1559GasProvider.java
+++ b/core/src/main/java/org/web3j/tx/gas/CappedDynamicEIP1559GasProvider.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.tx.gas;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import org.web3j.protocol.Web3j;
+
+public class CappedDynamicEIP1559GasProvider extends DynamicEIP1559GasProvider {
+    private final BigInteger maxFeePerGas;
+
+    CappedDynamicEIP1559GasProvider(
+            Web3j web3j,
+            long chainId,
+            PriorityGasProvider.Priority priority,
+            BigDecimal customMultiplier,
+            BigInteger maxFeePerGas) {
+        super(web3j, chainId, priority, customMultiplier);
+        if (maxFeePerGas.signum() <= 0) {
+            throw new IllegalArgumentException("maxFeePerGas must be positive");
+        }
+        this.maxFeePerGas = maxFeePerGas;
+    }
+
+    @Override
+    public BigInteger getMaxFeePerGas() {
+        return super.getMaxFeePerGas().min(maxFeePerGas);
+    }
+
+    @Override
+    public BigInteger getMaxPriorityFeePerGas() {
+        return super.getMaxPriorityFeePerGas().min(maxFeePerGas);
+    }
+}

--- a/core/src/main/java/org/web3j/tx/gas/CappedDynamicEIP1559GasProvider.java
+++ b/core/src/main/java/org/web3j/tx/gas/CappedDynamicEIP1559GasProvider.java
@@ -17,7 +17,13 @@ import java.math.BigInteger;
 
 import org.web3j.protocol.Web3j;
 
+/**
+ * {@link DynamicEIP1559GasProvider} that enforces a configurable upper limit (cap) on the EIP-1559
+ * gas fees. This protects against paying excessive fees during gas price spikes on public networks.
+ */
 public class CappedDynamicEIP1559GasProvider extends DynamicEIP1559GasProvider {
+
+    /** Upper limit (in wei) applied to the calculated gas fees. */
     private final BigInteger maxFeePerGas;
 
     CappedDynamicEIP1559GasProvider(
@@ -33,11 +39,22 @@ public class CappedDynamicEIP1559GasProvider extends DynamicEIP1559GasProvider {
         this.maxFeePerGas = maxFeePerGas;
     }
 
+    /**
+     * Returns the dynamically calculated max fee per gas, capped at the configured upper limit.
+     *
+     * @return the smaller of the calculated fee and the configured maximum
+     */
     @Override
     public BigInteger getMaxFeePerGas() {
         return super.getMaxFeePerGas().min(maxFeePerGas);
     }
 
+    /**
+     * Returns the dynamically calculated max priority fee per gas, capped at the configured upper
+     * limit so it never exceeds the overall max fee per gas.
+     *
+     * @return the smaller of the calculated priority fee and the configured maximum
+     */
     @Override
     public BigInteger getMaxPriorityFeePerGas() {
         return super.getMaxPriorityFeePerGas().min(maxFeePerGas);

--- a/core/src/main/java/org/web3j/tx/gas/CappedDynamicEIP1559GasProvider.java
+++ b/core/src/main/java/org/web3j/tx/gas/CappedDynamicEIP1559GasProvider.java
@@ -14,6 +14,7 @@ package org.web3j.tx.gas;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Objects;
 
 import org.web3j.protocol.Web3j;
 
@@ -26,13 +27,26 @@ public class CappedDynamicEIP1559GasProvider extends DynamicEIP1559GasProvider {
     /** Upper limit (in wei) applied to the calculated gas fees. */
     private final BigInteger maxFeePerGas;
 
-    CappedDynamicEIP1559GasProvider(
+    public CappedDynamicEIP1559GasProvider(Web3j web3j, long chainId, BigInteger maxFeePerGas) {
+        this(web3j, chainId, Priority.NORMAL, BigDecimal.ONE, maxFeePerGas);
+    }
+
+    public CappedDynamicEIP1559GasProvider(
+            Web3j web3j,
+            long chainId,
+            PriorityGasProvider.Priority priority,
+            BigInteger maxFeePerGas) {
+        this(web3j, chainId, priority, BigDecimal.ONE, maxFeePerGas);
+    }
+
+    public CappedDynamicEIP1559GasProvider(
             Web3j web3j,
             long chainId,
             PriorityGasProvider.Priority priority,
             BigDecimal customMultiplier,
             BigInteger maxFeePerGas) {
         super(web3j, chainId, priority, customMultiplier);
+        Objects.requireNonNull(maxFeePerGas, "maxFeePerGas must not be null");
         if (maxFeePerGas.signum() <= 0) {
             throw new IllegalArgumentException("maxFeePerGas must be positive");
         }
@@ -58,5 +72,10 @@ public class CappedDynamicEIP1559GasProvider extends DynamicEIP1559GasProvider {
     @Override
     public BigInteger getMaxPriorityFeePerGas() {
         return super.getMaxPriorityFeePerGas().min(maxFeePerGas);
+    }
+
+    @Override
+    public BigInteger getGasPrice() {
+        return super.getGasPrice().min(maxFeePerGas);
     }
 }

--- a/core/src/test/java/org/web3j/protocol/core/RequestTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/RequestTest.java
@@ -160,8 +160,7 @@ class RequestTest extends RequestTester {
     void testTxPoolInspect() throws Exception {
         web3j.txPoolInspect().send();
 
-        verifyResult(
-                "{\"jsonrpc\":\"2.0\",\"method\":\"txpool_inspect\",\"params\":[],\"id\":1}");
+        verifyResult("{\"jsonrpc\":\"2.0\",\"method\":\"txpool_inspect\",\"params\":[],\"id\":1}");
     }
 
     @Test

--- a/core/src/test/java/org/web3j/protocol/core/methods/response/TxPoolInspectTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/methods/response/TxPoolInspectTest.java
@@ -46,9 +46,15 @@ public class TxPoolInspectTest extends ResponseTester {
 
         assertEquals(
                 "0.1 ETH + 21000 gas",
-                content.getResult().getPending().get("0x0032D05F320fa74C871E892F48F0e6387c0Dfe95").get(BigInteger.ZERO));
+                content.getResult()
+                        .getPending()
+                        .get("0x0032D05F320fa74C871E892F48F0e6387c0Dfe95")
+                        .get(BigInteger.ZERO));
         assertEquals(
                 "0.05 ETH + 21000 gas",
-                content.getResult().getQueued().get("0x00Bf700CeB382877F8bFa38b05fcC81126f4f228").get(new BigInteger("49")));
+                content.getResult()
+                        .getQueued()
+                        .get("0x00Bf700CeB382877F8bFa38b05fcC81126f4f228")
+                        .get(new BigInteger("49")));
     }
 }

--- a/core/src/test/java/org/web3j/protocol/http/HttpServiceTest.java
+++ b/core/src/test/java/org/web3j/protocol/http/HttpServiceTest.java
@@ -101,9 +101,7 @@ class HttpServiceTest {
             assertEquals(
                     e.getMessage(),
                     "Invalid response received: " + response.code() + "; " + content);
-            assertEquals(
-                    response.code(),
-                    e.getCode());
+            assertEquals(response.code(), e.getCode());
             return;
         }
 

--- a/core/src/test/java/org/web3j/tx/gas/CappedDynamicEIP1559GasProviderTest.java
+++ b/core/src/test/java/org/web3j/tx/gas/CappedDynamicEIP1559GasProviderTest.java
@@ -1,0 +1,59 @@
+package org.web3j.tx.gas;
+
+import org.junit.jupiter.api.Test;
+import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.DefaultBlockParameterName;
+import org.web3j.protocol.core.Request;
+import org.web3j.protocol.core.methods.response.EthBlock;
+import org.web3j.protocol.core.methods.response.EthMaxPriorityFeePerGas;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CappedDynamicEIP1559GasProviderTest {
+
+	@Test
+	void capsMaxFeePerGas() throws Exception {
+		Web3j web3j = mock(Web3j.class);
+		Request<?, EthBlock> blockRequest = mock(Request.class);
+		EthBlock blockResponse = mock(EthBlock.class);
+		EthBlock.Block block = mock(EthBlock.Block.class);
+		Request<?, EthMaxPriorityFeePerGas> priorityFeeRequest = mock(Request.class);
+		EthMaxPriorityFeePerGas priorityFeeResponse = mock(EthMaxPriorityFeePerGas.class);
+
+		doReturn(blockRequest).when(web3j).ethGetBlockByNumber(DefaultBlockParameterName.LATEST, false);
+		when(blockRequest.send()).thenReturn(blockResponse);
+		when(blockResponse.getBlock()).thenReturn(block);
+		when(block.getBaseFeePerGas()).thenReturn(BigInteger.valueOf(100));
+		doReturn(priorityFeeRequest).when(web3j).ethMaxPriorityFeePerGas();
+		when(priorityFeeRequest.send()).thenReturn(priorityFeeResponse);
+		when(priorityFeeResponse.getMaxPriorityFeePerGas()).thenReturn(BigInteger.valueOf(20));
+
+		CappedDynamicEIP1559GasProvider gasProvider = new CappedDynamicEIP1559GasProvider(
+				web3j,
+				1L,
+				PriorityGasProvider.Priority.NORMAL,
+				BigDecimal.ONE,
+				BigInteger.valueOf(150));
+
+		assertEquals(BigInteger.valueOf(150), gasProvider.getMaxFeePerGas());
+	}
+
+	@Test
+	void rejectsNonPositiveMaxFeePerGas() {
+		assertThrows(
+				IllegalArgumentException.class,
+				() -> new CappedDynamicEIP1559GasProvider(
+						mock(Web3j.class),
+						1L,
+						PriorityGasProvider.Priority.NORMAL,
+						BigDecimal.ONE,
+						BigInteger.ZERO));
+	}
+}

--- a/core/src/test/java/org/web3j/tx/gas/CappedDynamicEIP1559GasProviderTest.java
+++ b/core/src/test/java/org/web3j/tx/gas/CappedDynamicEIP1559GasProviderTest.java
@@ -1,14 +1,28 @@
+/*
+ * Copyright 2025 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package org.web3j.tx.gas;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
 import org.junit.jupiter.api.Test;
+
 import org.web3j.protocol.Web3j;
 import org.web3j.protocol.core.DefaultBlockParameterName;
 import org.web3j.protocol.core.Request;
 import org.web3j.protocol.core.methods.response.EthBlock;
+import org.web3j.protocol.core.methods.response.EthGasPrice;
 import org.web3j.protocol.core.methods.response.EthMaxPriorityFeePerGas;
-
-import java.math.BigDecimal;
-import java.math.BigInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -18,42 +32,125 @@ import static org.mockito.Mockito.when;
 
 public class CappedDynamicEIP1559GasProviderTest {
 
-	@Test
-	void capsMaxFeePerGas() throws Exception {
-		Web3j web3j = mock(Web3j.class);
-		Request<?, EthBlock> blockRequest = mock(Request.class);
-		EthBlock blockResponse = mock(EthBlock.class);
-		EthBlock.Block block = mock(EthBlock.Block.class);
-		Request<?, EthMaxPriorityFeePerGas> priorityFeeRequest = mock(Request.class);
-		EthMaxPriorityFeePerGas priorityFeeResponse = mock(EthMaxPriorityFeePerGas.class);
+    @Test
+    void capsMaxFeePerGas() throws Exception {
+        Web3j web3j = mock(Web3j.class);
+        Request<?, EthBlock> blockRequest = mock(Request.class);
+        EthBlock blockResponse = mock(EthBlock.class);
+        EthBlock.Block block = mock(EthBlock.Block.class);
+        Request<?, EthMaxPriorityFeePerGas> priorityFeeRequest = mock(Request.class);
+        EthMaxPriorityFeePerGas priorityFeeResponse = mock(EthMaxPriorityFeePerGas.class);
 
-		doReturn(blockRequest).when(web3j).ethGetBlockByNumber(DefaultBlockParameterName.LATEST, false);
-		when(blockRequest.send()).thenReturn(blockResponse);
-		when(blockResponse.getBlock()).thenReturn(block);
-		when(block.getBaseFeePerGas()).thenReturn(BigInteger.valueOf(100));
-		doReturn(priorityFeeRequest).when(web3j).ethMaxPriorityFeePerGas();
-		when(priorityFeeRequest.send()).thenReturn(priorityFeeResponse);
-		when(priorityFeeResponse.getMaxPriorityFeePerGas()).thenReturn(BigInteger.valueOf(20));
+        doReturn(blockRequest)
+                .when(web3j)
+                .ethGetBlockByNumber(DefaultBlockParameterName.LATEST, false);
+        when(blockRequest.send()).thenReturn(blockResponse);
+        when(blockResponse.getBlock()).thenReturn(block);
+        when(block.getBaseFeePerGas()).thenReturn(BigInteger.valueOf(100));
+        doReturn(priorityFeeRequest).when(web3j).ethMaxPriorityFeePerGas();
+        when(priorityFeeRequest.send()).thenReturn(priorityFeeResponse);
+        when(priorityFeeResponse.getMaxPriorityFeePerGas()).thenReturn(BigInteger.valueOf(20));
 
-		CappedDynamicEIP1559GasProvider gasProvider = new CappedDynamicEIP1559GasProvider(
-				web3j,
-				1L,
-				PriorityGasProvider.Priority.NORMAL,
-				BigDecimal.ONE,
-				BigInteger.valueOf(150));
+        CappedDynamicEIP1559GasProvider gasProvider =
+                new CappedDynamicEIP1559GasProvider(
+                        web3j,
+                        1L,
+                        PriorityGasProvider.Priority.NORMAL,
+                        BigDecimal.ONE,
+                        BigInteger.valueOf(150));
 
-		assertEquals(BigInteger.valueOf(150), gasProvider.getMaxFeePerGas());
-	}
+        assertEquals(BigInteger.valueOf(150), gasProvider.getMaxFeePerGas());
+    }
 
-	@Test
-	void rejectsNonPositiveMaxFeePerGas() {
-		assertThrows(
-				IllegalArgumentException.class,
-				() -> new CappedDynamicEIP1559GasProvider(
-						mock(Web3j.class),
-						1L,
-						PriorityGasProvider.Priority.NORMAL,
-						BigDecimal.ONE,
-						BigInteger.ZERO));
-	}
+    @Test
+    void leavesMaxFeePerGasUncappedWhenBelowCap() throws Exception {
+        Web3j web3j = mock(Web3j.class);
+        Request<?, EthBlock> blockRequest = mock(Request.class);
+        EthBlock blockResponse = mock(EthBlock.class);
+        EthBlock.Block block = mock(EthBlock.Block.class);
+        Request<?, EthMaxPriorityFeePerGas> priorityFeeRequest = mock(Request.class);
+        EthMaxPriorityFeePerGas priorityFeeResponse = mock(EthMaxPriorityFeePerGas.class);
+
+        doReturn(blockRequest)
+                .when(web3j)
+                .ethGetBlockByNumber(DefaultBlockParameterName.LATEST, false);
+        when(blockRequest.send()).thenReturn(blockResponse);
+        when(blockResponse.getBlock()).thenReturn(block);
+        when(block.getBaseFeePerGas()).thenReturn(BigInteger.valueOf(100));
+        doReturn(priorityFeeRequest).when(web3j).ethMaxPriorityFeePerGas();
+        when(priorityFeeRequest.send()).thenReturn(priorityFeeResponse);
+        when(priorityFeeResponse.getMaxPriorityFeePerGas()).thenReturn(BigInteger.valueOf(20));
+
+        CappedDynamicEIP1559GasProvider gasProvider =
+                new CappedDynamicEIP1559GasProvider(web3j, 1L, BigInteger.valueOf(500));
+
+        assertEquals(BigInteger.valueOf(220), gasProvider.getMaxFeePerGas());
+    }
+
+    @Test
+    void capsMaxPriorityFeePerGas() throws Exception {
+        Web3j web3j = mock(Web3j.class);
+        Request<?, EthMaxPriorityFeePerGas> priorityFeeRequest = mock(Request.class);
+        EthMaxPriorityFeePerGas priorityFeeResponse = mock(EthMaxPriorityFeePerGas.class);
+
+        doReturn(priorityFeeRequest).when(web3j).ethMaxPriorityFeePerGas();
+        when(priorityFeeRequest.send()).thenReturn(priorityFeeResponse);
+        when(priorityFeeResponse.getMaxPriorityFeePerGas()).thenReturn(BigInteger.valueOf(20));
+
+        CappedDynamicEIP1559GasProvider gasProvider =
+                new CappedDynamicEIP1559GasProvider(web3j, 1L, BigInteger.valueOf(15));
+
+        assertEquals(BigInteger.valueOf(15), gasProvider.getMaxPriorityFeePerGas());
+    }
+
+    @Test
+    void capsLegacyGasPrice() throws Exception {
+        Web3j web3j = mock(Web3j.class);
+        Request<?, EthGasPrice> gasPriceRequest = mock(Request.class);
+        EthGasPrice gasPriceResponse = mock(EthGasPrice.class);
+
+        doReturn(gasPriceRequest).when(web3j).ethGasPrice();
+        when(gasPriceRequest.send()).thenReturn(gasPriceResponse);
+        when(gasPriceResponse.getGasPrice()).thenReturn(BigInteger.valueOf(100));
+
+        CappedDynamicEIP1559GasProvider gasProvider =
+                new CappedDynamicEIP1559GasProvider(web3j, 1L, BigInteger.valueOf(90));
+
+        assertEquals(BigInteger.valueOf(90), gasProvider.getGasPrice());
+    }
+
+    @Test
+    void rejectsNullMaxFeePerGas() {
+        assertThrows(
+                NullPointerException.class,
+                () ->
+                        new CappedDynamicEIP1559GasProvider(
+                                mock(Web3j.class),
+                                1L,
+                                PriorityGasProvider.Priority.NORMAL,
+                                BigDecimal.ONE,
+                                null));
+    }
+
+    @Test
+    void rejectsNonPositiveMaxFeePerGas() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        new CappedDynamicEIP1559GasProvider(
+                                mock(Web3j.class),
+                                1L,
+                                PriorityGasProvider.Priority.NORMAL,
+                                BigDecimal.ONE,
+                                BigInteger.ZERO));
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        new CappedDynamicEIP1559GasProvider(
+                                mock(Web3j.class),
+                                1L,
+                                PriorityGasProvider.Priority.NORMAL,
+                                BigDecimal.ONE,
+                                BigInteger.valueOf(-1)));
+    }
 }


### PR DESCRIPTION
### What does this PR do?
Adds `CappedDynamicEIP1559GasProvider`, a new gas provider that extends `DynamicEIP1559GasProvider` and enforces an upper bound (`maxFeePerGas`) on both the max fee per gas and the max priority fee per gas. This prevents transactions from being submitted with gas fees exceeding a user-defined cap, regardless of current network conditions.

### Where should the reviewer start?

- `core/src/main/java/org/web3j/tx/gas/CappedDynamicEIP1559GasProvider.java` — the new class and its cap logic in `getMaxFeePerGas()` / `getMaxPriorityFeePerGas()`
- `core/src/test/java/org/web3j/tx/gas/CappedDynamicEIP1559GasProviderTest.java` — unit tests covering the cap behavior and input validation

### Why is it needed?
In volatile market conditions, dynamically estimated gas fees can spike unexpectedly. This provider gives users a simple way to set a hard ceiling on gas costs, ensuring transactions stay within a predictable cost range without having to implement custom fee logic.

## Checklist

- [x] I've read the contribution guidelines.
- [x] I've added tests (if applicable).
- [x] I've added a changelog entry if necessary.